### PR TITLE
Améliore la grammaire des expressions

### DIFF
--- a/règles/rémunération-travail/aides/ok/cice.yaml
+++ b/règles/rémunération-travail/aides/ok/cice.yaml
@@ -15,7 +15,7 @@
   formule:
     multiplication:
       assiette: assiette cotisations sociales
-      taux: 0.07
+      taux: 7%
 
 - espace: contrat salarié
   nom: plafond cice
@@ -25,5 +25,4 @@
 
 - espace: contrat salarié
   nom: multiplicateur cice
-  formule:
-    taux: 2.5
+  formule: 2.5

--- a/règles/rémunération-travail/aides/ok/réduction-générale-bas-salaires-fillon.yaml
+++ b/règles/rémunération-travail/aides/ok/réduction-générale-bas-salaires-fillon.yaml
@@ -57,10 +57,8 @@
 
 - espace: contrat salarié
   nom: multiplicateur réduction générale
-  formule:
-    taux: 1.6
+  formule: 1.6
 
 - espace: contrat salarié
   nom: smic mensuel
-  formule:
-    taux: 1480.27
+  formule: 1480.27

--- a/règles/rémunération-travail/cotisations/ok/allocations-familiales.yaml
+++ b/règles/rémunération-travail/cotisations/ok/allocations-familiales.yaml
@@ -20,7 +20,4 @@
 
 - espace: contrat salarié
   nom: plafond réduction allocations familiales
-  formule:
-    multiplication:
-      assiette: smic mensuel
-      taux: 3.5
+  formule: smic mensuel * 3.5

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -72,7 +72,7 @@ Constant -> "'" [ .'a-zA-Z\u00C0-\u017F ]:+ "'" {% d => ({
 VariableFragment -> VariableWord (_ VariableWord {% d=> ' ' + d[1] %}):* {% d => d[0] + d[1].join('') %}
 
 
-VariableWord -> ['a-zA-Z\u00C0-\u017F]:+     {% d => d[0].join('') %}
+VariableWord -> [a-zA-Z\u00C0-\u017F] ['a-zA-Z\u00C0-\u017F]:*     {% d => d[0] + d[1].join('') %}
 
 Dot -> [\.] {% d => null %}
 

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -2,11 +2,12 @@
 
 
 main ->
-			CalcExpression {% id %}
+		  CalcExpression {% id %}
 		| Variable {% id %}
 		| NegatedVariable {% id %}
 		| ModifiedVariable {% id %}
 		| FilteredVariable {% id %}
+		| percentage {% id %}
 		| Comparison {% id %}
 
 Comparison -> Comparable _ ComparisonOperator _ Comparable {% d => ({
@@ -16,7 +17,7 @@ Comparison -> Comparable _ ComparisonOperator _ Comparable {% d => ({
 	explanation: [d[0], d[4]]
 }) %}
 
-Comparable -> (int | CalcExpression | Variable | Constant) {% d => d[0][0] %}
+Comparable -> (number | percentage | CalcExpression | Variable | Constant) {% d => d[0][0] %}
 
 ComparisonOperator -> ">" | "<" | ">=" | "<=" | "=" | "!="
 
@@ -44,7 +45,8 @@ CalcExpression -> Term _ ArithmeticOperator _ Term {% d => ({
 
 Term -> Variable {% id %}
 		| FilteredVariable {% id %}
-		| int {% id %}
+		| number {% id %}
+		| percentage {% id %}
 
 ArithmeticOperator -> "+" {% id %}
 	| "-" {% id %}
@@ -77,4 +79,6 @@ Dot -> [\.] {% d => null %}
 _ -> [\s]     {% d => null %}
 
 
-int -> [0-9]:+        {% d => ({category: 'value', nodeValue: parseInt(+d[0].join(""))}) %}
+number -> [0-9]:+ ([\.] [0-9]:+):?        {% d => ({category: 'value', nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))}) %}
+
+percentage -> [0-9]:+ ([\.] [0-9]:+):? [\%]        {% d => ({category: 'percentage', nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))/100}) %}

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -72,7 +72,7 @@ Constant -> "'" [ .'a-zA-Z\u00C0-\u017F ]:+ "'" {% d => ({
 VariableFragment -> VariableWord (_ VariableWord {% d=> ' ' + d[1] %}):* {% d => d[0] + d[1].join('') %}
 
 
-VariableWord -> [a-zA-Z\u00C0-\u017F]:+     {% d => d[0].join('') %}
+VariableWord -> ['a-zA-Z\u00C0-\u017F]:+     {% d => d[0].join('') %}
 
 Dot -> [\.] {% d => null %}
 

--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -6,11 +6,6 @@ import {makeJsx, evaluateNode, rewriteNode, evaluateArray, evaluateArrayWithFilt
 
 let constantNode = constant => ({nodeValue: constant})
 
-let transformPercentage = s =>
-	R.contains('%')(s) ?
-		+s.replace('%', '') / 100
-	: +s
-
 let decompose = (recurse, k, v) => {
 	let
 		subProps = R.dissoc('composantes')(v),
@@ -435,17 +430,13 @@ export let mecanismScale = (recurse,k,v) => {
 			: R.has('au-dessus de')(t) ? {de: t['au-dessus de'], 'à': Infinity, taux: t.taux}
 				: t)
 
-	let aliased = {
-		...v,
-		multiplicateur: v['multiplicateur des tranches']
-	}
 
 	let objectShape = {
 		assiette:false,
-		multiplicateur:false
+		'multiplicateur des tranches':false
 	}
 
-	let effect = ({assiette, multiplicateur, tranches}) => {
+	let effect = ({assiette, 'multiplicateur des tranches': multiplicateur, tranches}) => {
 		//TODO traiter la récursion 'de', 'à', 'taux' pour qu'ils puissent contenir des calculs
 		// (c'est partiellement le cas pour 'taux' qui est calculé mais pas ses variables manquantes)
 		// ou pour les cas où toutes les tranches n'ont pas un multiplicateur commun (ex. plafond
@@ -472,7 +463,7 @@ export let mecanismScale = (recurse,k,v) => {
 		}
 
 	let explanation = {
-				...parseObject(recurse,objectShape,aliased),
+				...parseObject(recurse,objectShape,v),
 				tranches
 			},
 		evaluate = evaluateObject(objectShape,effect)

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -8,7 +8,7 @@ import Grammar from './grammar.ne'
 import {Node, Leaf} from './traverse-common-jsx'
 import {
 	mecanismOneOf,mecanismAllOf,mecanismNumericalSwitch,mecanismSum,mecanismProduct,
-	mecanismPercentage,mecanismScale,mecanismMax,mecanismMin, mecanismError, mecanismComplement
+	mecanismScale,mecanismMax,mecanismMin, mecanismError, mecanismComplement
 } from "./mecanisms"
 import {evaluateNode, rewriteNode, collectNodeMissing, makeJsx} from './evaluation'
 
@@ -302,7 +302,6 @@ let treat = (rules, rule) => rawNode => {
 					'une de ces conditions':	mecanismOneOf,
 					'toutes ces conditions':	mecanismAllOf,
 					'aiguillage numérique':		mecanismNumericalSwitch,
-					'taux':						mecanismPercentage,
 					'somme':					mecanismSum,
 					'multiplication':			mecanismProduct,
 					'barème':					mecanismScale,

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -175,7 +175,7 @@ let treat = (rules, rule) => rawNode => {
 			if (additionnalResults && additionnalResults.length > 0)
 				throw "Attention ! L'expression <" + rawNode + '> ne peut être traitée de façon univoque'
 
-			if (!R.contains(parseResult.category)(['variable', 'calcExpression', 'filteredVariable', 'comparison', 'negatedVariable']))
+			if (!R.contains(parseResult.category)(['variable', 'calcExpression', 'filteredVariable', 'comparison', 'negatedVariable', 'percentage']))
 				throw "Attention ! Erreur de traitement de l'expression : " + rawNode
 
 			if (parseResult.category == 'variable')
@@ -187,6 +187,15 @@ let treat = (rules, rule) => rawNode => {
 				return buildNegatedVariable(
 					fillVariableNode(rules, rule)(parseResult.variable)
 				)
+
+			// We don't need to handle category == 'value' because YAML then returns it as
+			// numerical value, not a String: it goes to treatNumber
+			if (parseResult.category == 'percentage') {
+				return {
+					nodeValue: parseResult.nodeValue,
+					jsx:  nodeValue => <span className="percentage">{rawNode}</span>
+				}
+			}
 
 			if (parseResult.category == 'calcExpression' || parseResult.category == 'comparison') {
 				let evaluate = (situation, parsedRules, node) => {
@@ -224,8 +233,14 @@ let treat = (rules, rule) => rawNode => {
 							[R.propEq('category', 'filteredVariable'), fillFiltered],
 							[R.propEq('category', 'value'), node =>
 								({
-									evaluate: (situation, parsedRules, me) => ({...me, nodeValue: node.nodeValue}),
+									nodeValue: node.nodeValue,
 									jsx:  nodeValue => <span className="value">{nodeValue}</span>
+								})
+							],
+							[R.propEq('category', 'percentage'), node =>
+								({
+									nodeValue: node.nodeValue,
+									jsx:  nodeValue => <span className="value">{nodeValue*100}%</span>
 								})
 							]
 						])

--- a/test/generateQuestions.test.js
+++ b/test/generateQuestions.test.js
@@ -153,7 +153,8 @@ describe('collectMissingVariables', function() {
               {si: "3 > 2", "tranches":[{"en-dessous de":1, taux: 0.1},{de:1, "à": 2, taux: 1.8}, ,{"au-dessus de":2, taux: 10}]},
             ]
           }}},
-          {nom: "dix", espace: "top"}],
+          {nom: "dix", espace: "top"},
+          {nom: "deux", espace: "top"}],
         rules = rawRules.map(enrichRule),
         situation = analyseTopDown(rules,"startHere")(stateSelector),
         result = collectMissingVariables()(stateSelector,situation)

--- a/test/mecanisms.test.js
+++ b/test/mecanisms.test.js
@@ -11,6 +11,9 @@ import {collectMissingVariables} from '../source/engine/generateQuestions'
 import testSuites from './load-mecanism-tests'
 import R from 'ramda'
 
+// By luck this works as expected for both null and undefined, * but with different branches failing :O *
+let isFloat = n => Number(n) === n && n % 1 !== 0
+
 describe('Mécanismes', () =>
   testSuites.map( suite =>
     suite.map(({exemples, nom, test}) =>
@@ -25,7 +28,10 @@ describe('Mécanismes', () =>
               missing = collectMissingVariables()(stateSelector,analysis)
 
             // console.log('JSON.stringify(analysis', JSON.stringify(analysis))
-            if (valeur !== undefined) {
+            if (isFloat(valeur)) {
+              expect(analysis.root.nodeValue).to.be.closeTo(valeur,0.001)
+            }
+            else if (valeur !== undefined) {
               expect(analysis.root)
                 .to.have.property(
                   'nodeValue',

--- a/test/mécanismes/barème.yaml
+++ b/test/mécanismes/barème.yaml
@@ -1,0 +1,24 @@
+- nom: assiette
+  format: €
+
+- nom: base
+  format: €
+
+- nom: ARRCO
+  test: Barème en taux marginaux
+  formule:
+    barème:
+      assiette: assiette
+      multiplicateur des tranches: base
+      tranches:
+      - en-dessous de: 1
+        taux: 4.65%
+      - au-dessus de: 1
+        taux: 0%
+
+  exemples:
+    - nom: exemple
+      situation:
+        assiette: 3000
+        base: 5000
+      valeur attendue: 139.5

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -98,13 +98,6 @@ describe('analyseSituation with mecanisms', function() {
 
   it('should handle percentages', function() {
     let rawRules = [
-          {nom: "startHere", formule: {taux: "35%"}, espace: "top"}],
-        rules = rawRules.map(enrichRule)
-    expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',0.35)
-  });
-
-  it('should handle raw percentages', function() {
-    let rawRules = [
           {nom: "startHere", formule: "35%", espace: "top"}],
         rules = rawRules.map(enrichRule)
     expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',0.35)

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -103,6 +103,13 @@ describe('analyseSituation with mecanisms', function() {
     expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',0.35)
   });
 
+  it('should handle raw percentages', function() {
+    let rawRules = [
+          {nom: "startHere", formule: "35%", espace: "top"}],
+        rules = rawRules.map(enrichRule)
+    expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',0.35)
+  });
+
   it('should handle sums', function() {
     let rawRules = [
           {nom: "startHere", formule: {"somme": [3200, "dix", 9]}},


### PR DESCRIPTION
Cette PR
- permet d'exprimer des flottants dans les expressions parsées et plus seulement des entiers 🚀 
- permet d'exprimer également des constantes en pourcentage
- du même coup, supprime mecanismPercentage devenu obsolète
- simplifie quelques formules que la limitation aux entiers rendait alambiquées

Cette PR est nécessaire pour #50 qui la prend comme base
