### PR TITLE
Intègre les exonérations liées au statut JEI

### DIFF
--- a/règles/rémunération-travail/aides/ok/jei.yaml
+++ b/règles/rémunération-travail/aides/ok/jei.yaml
@@ -15,6 +15,7 @@
   références:
     description: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31188
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-au-s/jeunes-entreprises-innovantes/quelle-exoneration.html
+    cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
   non applicable si: ≠ statut JEI
 

--- a/règles/rémunération-travail/aides/ok/jei.yaml
+++ b/règles/rémunération-travail/aides/ok/jei.yaml
@@ -1,0 +1,29 @@
+- espace: contrat salarié
+  nom: statut JEI
+  titre: Statut JEI
+  question: Profitez-vous du statut Jeune Entreprise Innovante pour cette embauche ?
+  description: |
+    Le statut de jeune entreprise innovante (JEI) a été créé par la loi de finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au moins de leurs charges à de la Recherche et Développement de bénéficier de certaines exonérations.
+
+- espace: contrat salarié
+  nom: exonération JEI
+  aide:
+    type: réduction de cotisations
+    démarches: non
+  description: |
+    Le statut de jeune entreprise innovante (JEI) a été créé par la loi de finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au moins de leurs charges à de la Recherche et Développement de bénéficier de certaines exonérations.
+  références:
+    description: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31188
+    calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-au-s/jeunes-entreprises-innovantes/quelle-exoneration.html
+
+  non applicable si: ≠ statut JEI
+
+  formule:
+    # TODO - le plafonnement à 4,5 smic, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
+    # il faut fournir un mécanisme "exonération" capable de recalculer une règle en introduisant un plafond
+    le minimum de:
+      - 1634.39
+      - somme:
+        - allocations familiales
+        - maladie (employeur)
+        - vieillesse (employeur)

--- a/règles/rémunération-travail/aides/ok/réduction-générale-bas-salaires-fillon.yaml
+++ b/règles/rémunération-travail/aides/ok/réduction-générale-bas-salaires-fillon.yaml
@@ -10,8 +10,12 @@
   références:
     description: https://www.service-public.fr/professionnels-entreprises/vosdroits/F24542
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html
+    cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
-  non applicable si: salaire brut > plafond réduction générale
+  non applicable si:
+    une de ces conditions:
+      - salaire brut > plafond réduction générale
+      - statut JEI
 
   formule:
     le minimum de:

--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -198,6 +198,7 @@
     somme:
       - CICE
       - réduction générale
+      - exonération JEI
 
 - espace: contrat salarié
   nom: Salaire


### PR DESCRIPTION
Cette implémentation tient compte du plafonnement à 4,5 fois le smic mais d'une façon qui n'est pas satisfaisante à long terme: l'exonération totale est plafonnée à une somme précalculée avec les valeurs de septembre 2017.

Pour réaliser le calcul de façon pérenne, il manque un mécanisme "exonération", ou plus généralement permettant le recalcul d'une règle en introduisant une variation, typiquement un plafonnement de la rémunération prise en compte pour ce calcul.
