### PR TITLE
Corrige la mise en cache des variables filtrées

### DIFF
--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -74,7 +74,9 @@ let fillVariableNode = (rules, rule) => (parseResult) => {
 		let dottedName = node.dottedName,
 			// On va vérifier dans le cache courant, dict, si la variable n'a pas été déjà évaluée
 			// En effet, l'évaluation dans le cas d'une variable qui a une formule, est coûteuse !
-			cached = dict[dottedName],
+			filter = situation("sys.filter"),
+			cacheName = dottedName + (filter ? "." + filter: ""),
+			cached = dict[cacheName],
 			// make parsedRules a dict object, that also serves as a cache of evaluation ?
 			variable = cached ? cached : findRuleByDottedName(parsedRules, dottedName),
 			variableIsCalculable = variable.formule != null,
@@ -101,7 +103,7 @@ let fillVariableNode = (rules, rule) => (parseResult) => {
 				...rewriteNode(node,nodeValue,explanation,collectMissing),
 				missingVariables,
 			}
-			dict[dottedName] = result
+			dict[cacheName] = result
 
 			return result
 	}

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
-import {enrichRule} from '../source/engine/rules'
-import {analyseSituation} from '../source/engine/traverse'
+import {rules as realRules, enrichRule} from '../source/engine/rules'
+import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
 
 let stateSelector = (state, name) => null
 
@@ -217,6 +217,23 @@ describe('analyseSituation with mecanisms', function() {
           }}}],
         rules = rawRules.map(enrichRule)
     expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',50+400+40)
+  });
+
+  // TODO - make this a smaller test case
+  it('should compute consistent values', function() {
+    let stateSelector = (name) => ({
+        "contrat salarié . CDD . événement . poursuite du CDD en CDI":"oui",
+        "contrat salarié . salaire brut":2300,
+        "contrat salarié . statut cadre":"non",
+        "entreprise . effectif":20
+      })[name]
+
+    let rules = realRules.map(enrichRule),
+        part = analyseTopDown(rules,"coût du travail")(stateSelector),
+        whole = analyseTopDown(rules,"Salaire")(stateSelector)
+
+    expect(part.root.nodeValue).to.be.closeTo(2971.44,0.01)
+    expect(whole.root.formule.explanation.explanation[1].nodeValue).to.be.closeTo(2971.44,0.01)
   });
 
 });

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -219,21 +219,25 @@ describe('analyseSituation with mecanisms', function() {
     expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',50+400+40)
   });
 
-  // TODO - make this a smaller test case
   it('should compute consistent values', function() {
-    let stateSelector = (name) => ({
-        "contrat salarié . CDD . événement . poursuite du CDD en CDI":"oui",
-        "contrat salarié . salaire brut":2300,
-        "contrat salarié . statut cadre":"non",
-        "entreprise . effectif":20
-      })[name]
-
-    let rules = realRules.map(enrichRule),
-        part = analyseTopDown(rules,"coût du travail")(stateSelector),
-        whole = analyseTopDown(rules,"Salaire")(stateSelector)
-
-    expect(part.root.nodeValue).to.be.closeTo(2971.44,0.01)
-    expect(whole.root.formule.explanation.explanation[1].nodeValue).to.be.closeTo(2971.44,0.01)
+    let rawRules = [
+          {nom: "startHere", espace: "top", formule: "composed (salarié) + composed (employeur)"},
+          {nom: "orHere", espace: "top", formule: "composed"},
+          {nom: "composed", espace: "top", formule: {"barème": {
+            assiette:2008,
+            "multiplicateur des tranches":1000,
+            composantes: [
+              {tranches:[{"en-dessous de":1, taux: 0.05},{de:1, "à": 2, taux: 0.4}, ,{"au-dessus de":2, taux: 5}],
+               attributs: {"dû par":"salarié"}
+              },
+              {tranches:[{"en-dessous de":1, taux: 0.05},{de:1, "à": 2, taux: 0.8}, ,{"au-dessus de":2, taux: 5}],
+               attributs: {"dû par":"employeur"}
+              }
+            ]
+          }}}],
+        rules = rawRules.map(enrichRule)
+    expect(analyseSituation(rules,"orHere")(stateSelector)).to.have.property('nodeValue',100+1200+80)
+    expect(analyseSituation(rules,"startHere")(stateSelector)).to.have.property('nodeValue',100+1200+80)
   });
 
 });


### PR DESCRIPTION
Lorsqu'une variable faisait l'objet d'un filtre (par exemple: "maladie (salarié)" pour obtenir la composante salariale des cotisations maladie) le cache était renseigné avec le nom de la variable, avec pour conséquence que le deuxième appel à la variable (par exemple "maladie (employeur)") renvoyait la valeur mise en cache, bien entendu incorrecte.