### PR TITLE
Admettre qu'on ne peut pas calculer les 'une possibilité' ;)

### DIFF
--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -18,7 +18,8 @@ export default class Algorithm extends React.Component {
 		showValues: true
 	}
 	render(){
-		let {traversedRule: rule, showValues} = this.props
+		let {traversedRule: rule, showValues} = this.props,
+			ruleWithoutFormula = !rule['formule'] || rule.formule.explanation['une possibilité']
 		return (
 			<div id="algorithm">
 				<section id="rule-rules" className={classNames({showValues})}>
@@ -34,7 +35,7 @@ export default class Algorithm extends React.Component {
 					}}
 					<section id="formule">
 						<h2>Calcul</h2>
-						{rule['formule'] ? makeJsx(rule['formule']) : <RuleWithoutFormula />}
+						{ruleWithoutFormula ? <RuleWithoutFormula /> : makeJsx(rule['formule'])}
 					</section>
 				</section>
 			</div>


### PR DESCRIPTION
Lorsqu'une règle a une formule "une possibilité", ce n'est pas (actuellement) une vraie formule, mais une variable non affectée: les traiter de la même façon que les règles sans formule.