### PR TITLE
Réserver les exemples aux règles "typées" (cotisation, etc)

### DIFF
--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -110,21 +110,6 @@
       - chômage (salarié)
       - APEC (salarié)
 
-  exemples:
-    - nom: salaire médian, non cadre
-      situation:
-        CDD . événement . poursuite du CDD en CDI: oui
-        salaire de base: 2300
-        statut cadre: non
-      valeur attendue: 510.83
-
-    - nom: salaire médian, cadre
-      situation:
-        CDD . événement . poursuite du CDD en CDI: oui
-        salaire de base: 2300
-        statut cadre: oui
-      valeur attendue: 543.84
-
 - espace: contrat salarié
   nom: cotisations patronales
   formule:
@@ -150,23 +135,6 @@
       - cotisation pénibilité
       - taxe sur les salaires
       - CDD . surcoût CDD
-
-  exemples:
-    - nom: salaire médian, non cadre
-      situation:
-        CDD . événement . poursuite du CDD en CDI: oui
-        salaire de base: 2300
-        statut cadre: non
-        entreprise . effectif: 1
-      valeur attendue: 948.66
-
-    - nom: salaire médian, cadre
-      situation:
-        CDD . événement . poursuite du CDD en CDI: oui
-        salaire de base: 2300
-        statut cadre: oui
-        entreprise . effectif: 1
-      valeur attendue: 1032.72
 
 - espace: contrat salarié
   nom: salaire net


### PR DESCRIPTION
- [x] supprimer les exemples sur les règles de très haut niveau
- [ ] éviter d'afficher "cette règle manque d'exemples" qui n'est pas très vendeur ;)
- [ ] identifier les règles sur lesquelles les exemples sont pertinents et afficher le bloc exemples seulement là