### PR TITLE
Présenter les résultats de façon plus explicite

### DIFF
--- a/règles/rémunération-travail/entités/ok/CDD.yaml
+++ b/règles/rémunération-travail/entités/ok/CDD.yaml
@@ -54,7 +54,9 @@
   nom: surcoût
   titre: Dont surcoût CDD
   description: |
-    En France, le contrat à durée déterminée _est un contrat d'exception au CDI_ qui apporte à l'employeur plus de souplesse dans un cadre législatif précis, comportant en particulier des contreparties financières.
+    Le contrat à durée déterminée exige que l'employeur verse, au salarié ou aux organismes sociaux, certaines compensations
+    financières en contrepartie de la souplesse apportée par ce contrat; elles sont au nombre de 4. Certaines sont versées en
+    fin de contrat, d'autres avec chaque salaire mensuel; elles sont ici ramenées à leur coût mensuel.
   formule:
     somme: #TODO à l'avenir, exprimer une somme par requête de type : obligation applicable au CDD
       - CIF #cotisation
@@ -66,7 +68,7 @@
 - espace: contrat salarié . CDD
   nom: surcoût CDD
   description: |
-    En France, le contrat à durée déterminée _est un contrat d'exception au CDI_ qui apporte à l'employeur plus de souplesse dans un cadre législatif précis, comportant en particulier des contreparties financières.
+    En France, le contrat à durée déterminée est un contrat d'exception au CDI qui apporte à l'employeur plus de souplesse dans un cadre législatif précis, comportant en particulier des contreparties financières.
   formule:
     somme:
       - salaire net
@@ -76,7 +78,8 @@
   simulateur:
     titre: Simulateur CDD
     sous-titre: Découvrir le surcoût employeur du CDD par rapport au CDI
-    résultats: Le coût du travail faisant ressortir les cotisations spécifiques au CDD, calculées au mois.
+    résultats: Le coût du travail faisant ressortir les cotisations spécifiques au CDD.
+    indice: Par mois
     introduction:
       notes:
         - icône: fa-handshake-o

--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -172,20 +172,25 @@
 
 - espace: contrat salarié
   nom: salaire net
+  titre: Le salarié touchera
   description: |
-    C'est, en gros, le salaire brut moins les cotisations sociales. Ce salaire est plus important que le brut car c'est ce que le salarié reçoit sur son compte bancaire, et pourtant, le brut est très utilisé lors des négociations salariales.
+    Le salaire brut moins les cotisations sociales. C'est ce que le salarié reçoit sur son compte bancaire; cette somme peut varier en fonction de décisions politiques,
+    (augmentation ou diminution de cotisations) alors que le salaire brut est contractuel: il ne peut être que renégocié d'un commun accord.
   formule: salaire brut - cotisations salariales
 
 - espace: contrat salarié
+  titre: L'employeur versera
   nom: coût du travail
   description: |
-    C'est le salaire "super brut" diminué des aides financières
+    C'est ce que l'employeur devra réellement payer au total au salarié et aux organismes de collecte, en tenant compte
+    des aides et subventions qui lui sont reversées: c'est donc le coût total réel du travail pour l'employeur.
   formule: super brut - aides
 
 - espace: contrat salarié
   nom: super brut
   description: |
-    C'est le salaire de base augmenté des cotisations patronales.
+    C'est le salaire brut, plus les cotisations patronales. C'est ce que l'employeur doit en principe verser au total
+    pour l'emploi du salarié, mais en pratique certaines aides vont diminuer ce coût théorique du travail.
   formule:
     somme:
       - salaire brut

--- a/source/components/Results.css
+++ b/source/components/Results.css
@@ -7,7 +7,7 @@
 	padding: .6em 0;
 	text-align: center;
 	width: 100%;
-	height: 10em;
+	height: 12em;
 	position: fixed;
 	bottom: 0;
 	left: 0;

--- a/source/components/Results.js
+++ b/source/components/Results.js
@@ -30,13 +30,12 @@ export default class Results extends Component {
 			location
 		} = this.props
 
-
-		let explanation = R.has('root', analysedSituation) && clearDict() && getObjectives(situationGate, analysedSituation.root, analysedSituation.parsedRules),
-			hint = analysedSituation.root.simulateur && analysedSituation.root.simulateur.indice
+		let explanation = R.has('root', analysedSituation) && clearDict() && getObjectives(situationGate, analysedSituation.root, analysedSituation.parsedRules)
 
 		if (!explanation) return null
 
-		let onRulePage = R.contains('/regle/')(location.pathname)
+		let onRulePage = R.contains('/regle/')(location.pathname),
+			hint = analysedSituation.root.simulateur && analysedSituation.root.simulateur.indice
 
 		return (
 			<section id="results" className={classNames({show: showResults})}>

--- a/source/components/Results.js
+++ b/source/components/Results.js
@@ -31,7 +31,8 @@ export default class Results extends Component {
 		} = this.props
 
 
-		let explanation = R.has('root', analysedSituation) && clearDict() && getObjectives(situationGate, analysedSituation.root, analysedSituation.parsedRules)
+		let explanation = R.has('root', analysedSituation) && clearDict() && getObjectives(situationGate, analysedSituation.root, analysedSituation.parsedRules),
+			hint = analysedSituation.root.simulateur && analysedSituation.root.simulateur.indice
 
 		if (!explanation) return null
 
@@ -46,12 +47,11 @@ export default class Results extends Component {
 						</Link>
 					</div>
 					: <div id="results-titles">
-						<h2>Vos résultats <i className="fa fa-hand-o-right" aria-hidden="true"></i></h2>
+						<h2>{hint || "Vos résultats"}: <i className="fa fa-hand-o-right" aria-hidden="true"></i></h2>
 						{do {let text = R.path(['simulateur', 'résultats'])(analysedSituation.root)
 							text &&
 								<p id="resultText">{text}</p>
 						}}
-						<p id="understandTip"><i className="fa fa-lightbulb-o" aria-hidden="true"></i><em>Cliquez pour comprendre chaque calcul</em></p>
 					</div>
 				}
 				<ul>

--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -35,6 +35,7 @@ export default class Algorithm extends React.Component {
 					}}
 					<section id="formule">
 						<h2>Calcul</h2>
+						<p>Vous pouvez cliquer sur chaque valeur pour comprendre comment elle est calculée.</p>
 						{ruleWithoutFormula ? <RuleWithoutFormula /> : makeJsx(rule['formule'])}
 					</section>
 				</section>

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -59,7 +59,7 @@ export default class Rule extends Component {
 			situationExists = conversationStarted || this.state.example != null
 
 		let
-			{type, name, description} = this.rule,
+			{type, name, titre, description} = this.rule,
 			destinataire = R.path([type, 'destinataire'])(this.rule),
 			destinataireData = possiblesDestinataires[destinataire],
 			situationOrExampleRule = R.path(['example', 'rule'])(this.state) || this.rule,
@@ -68,7 +68,7 @@ export default class Rule extends Component {
 		return (
 			<div id="rule">
 				<Helmet>
-					<title>{capitalise0(name)}</title>
+					<title>{titre || capitalise0(name)}</title>
 					<meta name="description" content={description} />
 				</Helmet>
 				<h1>

--- a/source/components/rule/RuleValueVignette.css
+++ b/source/components/rule/RuleValueVignette.css
@@ -23,7 +23,7 @@
 	background: white;
 	border-radius: 3px;
 	white-space: nowrap;
-	height: 6em;
+	height: 8em;
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -38,9 +38,11 @@ export default ({
 								? "Vous n'êtes pas concerné"
 								: unsatisfied
 									? "En attente de vos réponses..."
-									: <span className="figure">
+									: <div><span className="figure">
 										{humanFigure(2)(ruleValue) + "€"}
-									</span>)}
+									</span>
+									<p><i className="fa fa-lightbulb-o" aria-hidden="true"></i><em>Pourquoi ?</em></p>
+									</div>)}
 					</p>
 				</div>
 			</Link>


### PR DESCRIPTION
Cette PR se penche sur les messages répétés se plaignant de ne pas comprendre les résultats du simulateur de surcoût, afin de tester l'hypothèse qu'une présentation plus explicite des résultats améliorerait les retours.

Concrètement elle
- [X] rend le texte "Vos résultats" configurable
- [X] précise grâce à ce texte que les objectifs sont calculés par mois
- [X] rend plus explicite les titres des salaire net et coût du travail
- [X] ménage de la place et affiche un CTA "pourquoi" sous chaque résultat
- [X] reformule les explications sur le salaire net et coût du travail
- [X] ajoute un CTA pour cliquer sur les variables d'une formule