### PR TITLE
Suivi des actions dans Piwik

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,23 +16,4 @@
 		<script type="text/javascript" src="/dist/bundle.js"></script>
 	</body>
 
-
-	<!-- Piwik -->
-	<script type="text/javascript">
-		var _paq = _paq || [];
-		_paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-		_paq.push(["setCookieDomain", "*.paie.sgmap.fr"]);
-		_paq.push(['trackPageView']);
-		_paq.push(['enableLinkTracking']);
-		(function() {
-			var u="//stats.data.gouv.fr/";
-			_paq.push(['setTrackerUrl', u+'piwik.php']);
-			_paq.push(['setSiteId', 10]);
-			var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-			g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-		})();
-	</script>
-	<noscript><p><img src="//stats.data.gouv.fr/piwik.php?idsite=10" style="border:0;" alt="" /></p></noscript>
-	<!-- End Piwik Code -->
-
 </html>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-helmet": "^5.1.3",
+    "react-piwik": "^1.0.7",
     "react-redux": "^5.0.5",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",

--- a/source/components/conversation/Explicable.js
+++ b/source/components/conversation/Explicable.js
@@ -6,6 +6,7 @@ import {connect} from 'react-redux'
 import {EXPLAIN_VARIABLE} from '../../actions'
 import {rules, findRuleByDottedName} from 'Engine/rules'
 
+import ReactPiwik from 'react-piwik';
 
 @connect(state => ({explained: state.explainedVariable}), dispatch => ({
 	explain: variableName => dispatch({type: EXPLAIN_VARIABLE, variableName})
@@ -40,7 +41,12 @@ export default class Explicable extends React.Component {
 					{ruleLabel}
 				<span
 					className="icon"
-					onClick={e => {e.preventDefault(); e.stopPropagation(); explain(dottedName)}}>
+					onClick={e => {
+						ReactPiwik.push(['trackEvent', 'help', dottedName]);
+						e.preventDefault();
+						e.stopPropagation();
+						explain(dottedName)
+					}}>
 					<i className="fa fa-info" aria-hidden="true"></i>
 				</span>
 			</span>

--- a/source/containers/Layout.js
+++ b/source/containers/Layout.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import './Layout.css'
 import './reset.css'
-import {Link, Route, BrowserRouter as Router, Switch} from 'react-router-dom'
+import {Link, Route, Router, Switch} from 'react-router-dom'
 import HomeEmbauche from 'Components/HomeEmbauche'
 import HomeSyso from 'Components/HomeSyso'
 import Rule from 'Components/rule/Rule'
@@ -13,8 +13,6 @@ import Results from 'Components/Results'
 import ReactPiwik from 'react-piwik';
 import createHistory from 'history/createBrowserHistory'
 
-const history = createHistory()
-
 const piwik = new ReactPiwik({
   url: 'stats.data.gouv.fr',
   siteId: 39,
@@ -22,6 +20,8 @@ const piwik = new ReactPiwik({
 });
 
 export default class Layout extends Component {
+	history = createHistory();
+
 	render() {
 		let displayWarning = ['/simu/', '/regle/'].find(t => window.location.href.toString().indexOf(t) > -1)
 
@@ -29,7 +29,7 @@ export default class Layout extends Component {
 		ReactPiwik.push(['trackPageView'])
 
 		return (
-			<Router history={piwik.connectToHistory(history)}>
+			<Router history={piwik.connectToHistory(this.history)}>
 				<div id="main">
 					<div id="ninetyPercent">
 						<div id="header">

--- a/source/containers/Layout.js
+++ b/source/containers/Layout.js
@@ -10,13 +10,26 @@ import Contact from 'Components/Contact'
 import Simulateur from 'Components/Simulateur'
 import Results from 'Components/Results'
 
+import ReactPiwik from 'react-piwik';
+import createHistory from 'history/createBrowserHistory'
+
+const history = createHistory()
+
+const piwik = new ReactPiwik({
+  url: 'stats.data.gouv.fr',
+  siteId: 39,
+  trackErrors: true,
+});
 
 export default class Layout extends Component {
 	render() {
 		let displayWarning = ['/simu/', '/regle/'].find(t => window.location.href.toString().indexOf(t) > -1)
 
+		// track the initial pageview
+		ReactPiwik.push(['trackPageView'])
+
 		return (
-			<Router>
+			<Router history={piwik.connectToHistory(history)}>
 				<div id="main">
 					<div id="ninetyPercent">
 						<div id="header">

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -11,6 +11,8 @@ import { STEP_ACTION, START_CONVERSATION, EXPLAIN_VARIABLE, CHANGE_THEME_COLOUR}
 
 import {analyseTopDown} from 'Engine/traverse'
 
+import ReactPiwik from 'react-piwik';
+
 // Our situationGate retrieves data from the "conversation" form
 let fromConversation = state => name => formValueSelector('conversation')(state, name)
 
@@ -57,6 +59,8 @@ export let reduceSteps = (state, action) => {
 		}
 	}
 	if (action.type == STEP_ACTION && action.name == 'fold') {
+		ReactPiwik.push(['trackEvent', 'answer', action.step+": "+situationGate(action.step)]);
+
 		let foldedSteps = [...state.foldedSteps, R.head(state.unfoldedSteps)],
 			unfoldedSteps = buildNextSteps(situationGate, flatRules, newState.analysedSituation)
 
@@ -82,6 +86,8 @@ export let reduceSteps = (state, action) => {
 		}
 	}
 	if (action.type == STEP_ACTION && action.name == 'unfold') {
+		ReactPiwik.push(['trackEvent', 'unfold', action.step]);
+
 		let stepFinder = R.propEq('name', action.step),
 			foldedSteps = R.reject(stepFinder)(state.foldedSteps),
 			extraSteps = R.reject(stepFinder)(state.extraSteps)


### PR DESCRIPTION
Cette PR remplace le suivi Piwik par une version intégrée à React qui suit correctement les changements de page internes et remonte également les réponses aux questions.

On peut par ailleurs envisager de connecter sur Piwik les retours qualitatifs (les boutons smiley) ce qui nous affranchirait des limites de stockage de Airtable. :) Il faudrait dans ce cas garder dans Airtable les verbatims car ils peuvent contenir des éléments d'identité.