### PR TITLE
Remplace la dépendance react-piwik par une version corrigée

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-helmet": "^5.2.0",
-    "react-piwik": "^1.0.7",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/source/components/Satisfaction.js
+++ b/source/components/Satisfaction.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 import './Satisfaction.css'
 import classNames from 'classnames'
 
-import ReactPiwik from 'react-piwik';
+import ReactPiwik from './Tracker';
 
 @connect(
 	state => ({

--- a/source/components/Simulateur.js
+++ b/source/components/Simulateur.js
@@ -14,7 +14,7 @@ import './Simulateur.css'
 import {capitalise0} from '../utils'
 import Conversation from './conversation/Conversation'
 
-import ReactPiwik from 'react-piwik';
+import ReactPiwik from './Tracker';
 
 let situationSelector = formValueSelector('conversation')
 

--- a/source/components/Tracker.js
+++ b/source/components/Tracker.js
@@ -1,0 +1,92 @@
+export default class Piwik {
+  constructor(opts) {
+    const options = opts;
+
+    options.enableLinkTracking = (options.enableLinkTracking !== undefined) ?
+                                    options.enableLinkTracking : true;
+    options.trackDocumentTitle = (options.trackDocumentTitle !== undefined) ?
+                                    options.trackDocumentTitle : true;
+
+    this.options = options;
+
+    if (this.options.url === undefined || this.options.siteId === undefined) {
+      throw new Error('PiwikTracker cannot be initialized! SiteId and url are mandatory.');
+    }
+
+    this.initPiwik();
+  }
+
+  initPiwik() {
+    let url = this.options.url;
+
+    if (url.indexOf('http://') !== -1 || url.indexOf('https://') !== -1) {
+      url = `${url}/`;
+    } else {
+      url = ((document.location.protocol === 'https:') ? `https://${url}/` : `http://${url}/`);
+    }
+
+    window._paq = window._paq || []; // eslint-disable-line  no-underscore-dangle
+
+    Piwik.push(['setSiteId', this.options.siteId]);
+    Piwik.push(['setTrackerUrl', `${url}piwik.php`]);
+
+    if (this.options.enableLinkTracking) {
+      Piwik.push(['enableLinkTracking']);
+    }
+
+    const scriptElement = document.createElement('script');
+    const refElement = document.getElementsByTagName('script')[0];
+
+    scriptElement.type = 'text/javascript';
+    scriptElement.defer = true;
+    scriptElement.async = true;
+    scriptElement.src = `${url}piwik.js`;
+    refElement.parentNode.insertBefore(scriptElement, refElement);
+
+    return {
+      push: this.push,
+      track: this.track,
+      connectToHistory: this.connectToHistory,
+      disconnectFromHistory: this.disconnectFromHistory,
+    };
+  }
+
+  static push(args) {
+    window._paq.push(args); // eslint-disable-line  no-underscore-dangle
+  }
+
+  connectToHistory(history) {
+    this.unlistenFromHistory = history.listen((loc) => {
+      this.track(loc);
+    });
+
+    return history;
+  }
+
+  disconnectFromHistory() {
+    if (this.unlistenFromHistory) {
+      this.unlistenFromHistory();
+
+      return true;
+    }
+
+    return false;
+  }
+
+  track(loc) {
+    const currentPath = loc.path || (loc.pathname + loc.search)/*.replace(/^\//, '')*/;
+
+    if (this.previousPath === currentPath) {
+      return;
+    }
+
+    if (this.options.trackDocumentTitle) {
+      Piwik.push(['setDocumentTitle', document.title]);
+    }
+
+    Piwik.push(['setCustomUrl', currentPath]);
+    Piwik.push(['trackPageView']);
+
+    this.previousPath = currentPath;
+  }
+}

--- a/source/components/conversation/Explicable.js
+++ b/source/components/conversation/Explicable.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import {EXPLAIN_VARIABLE} from '../../actions'
 import {rules, findRuleByDottedName} from 'Engine/rules'
 
-import ReactPiwik from 'react-piwik';
+import ReactPiwik from '../Tracker';
 
 @connect(state => ({explained: state.explainedVariable}), dispatch => ({
 	explain: variableName => dispatch({type: EXPLAIN_VARIABLE, variableName})

--- a/source/containers/Layout.js
+++ b/source/containers/Layout.js
@@ -4,8 +4,6 @@ import './reset.css'
 import './ribbon.css'
 
 import {Link, Route, Router, Switch} from 'react-router-dom'
-import ReactPiwik from 'react-piwik'
-import createHistory from 'history/createBrowserHistory'
 
 import HomeEmbauche from 'Components/HomeEmbauche'
 import HomeSyso from 'Components/HomeSyso'
@@ -15,6 +13,9 @@ import Contact from 'Components/Contact'
 import Simulateur from 'Components/Simulateur'
 import Results from 'Components/Results'
 import RulesList from "Components/RulesList"
+
+import ReactPiwik from 'Components/Tracker';
+import createHistory from 'history/createBrowserHistory'
 
 const piwik = new ReactPiwik({
 	url: 'stats.data.gouv.fr',

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -11,7 +11,7 @@ import { STEP_ACTION, START_CONVERSATION, EXPLAIN_VARIABLE, CHANGE_THEME_COLOUR}
 
 import {analyseTopDown} from 'Engine/traverse'
 
-import ReactPiwik from 'react-piwik';
+import ReactPiwik from 'Components/Tracker';
 
 // Our situationGate retrieves data from the "conversation" form
 let fromConversation = state => name => formValueSelector('conversation')(state, name)


### PR DESCRIPTION
Le module publié sur npm [supprime](https://github.com/guillaumeparis2000/react-piwik/blob/4a3d48dda71ff947ad82417570367db0471e16ea/src/React-Piwik.js#L77) les `/` en début d'adresse, ce qui est interprété par Piwik (? a vérifier) comme un lien relatif à l'URL initiale, ce qui génère des adresses incorrectes.

On peut aussi envisager des alternatives:
- https://github.com/joernroeder/piwik-react-router