### PR TITLE
Corrige les doublons lors du unfold

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "description": "Expérimentation sur les prélèvements sociaux en code",
   "engines": {
-    "node": ">=6.2.0"
+    "node": ">=6.2.0 <9.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",

--- a/règles/rémunération-travail/entités/ok/CDD.yaml
+++ b/règles/rémunération-travail/entités/ok/CDD.yaml
@@ -133,6 +133,7 @@
       entreprise . association non lucrative: 1
     par défaut:
       contrat salarié . temps partiel: non
+      contrat salarié . heures par semaine: 35
       contrat salarié . CDD . événement: non
       contrat salarié . CDD . congés non pris: 0
       contrat salarié . CDD . contrat jeune vacances: non

--- a/source/components/Simulateur.js
+++ b/source/components/Simulateur.js
@@ -22,8 +22,8 @@ let situationSelector = formValueSelector('conversation')
 @connect(
 	state => ({
 		situation: variableName => situationSelector(state, variableName),
+		currentQuestion: state.currentQuestion,
 		foldedSteps: state.foldedSteps,
-		unfoldedSteps: state.unfoldedSteps,
 		extraSteps: state.extraSteps,
 		themeColours: state.themeColours,
 		analysedSituation: state.analysedSituation,
@@ -62,7 +62,7 @@ export default class extends Component {
 
 		let
 			{started} = this.state,
-			{foldedSteps, extraSteps, unfoldedSteps, situation, situationGate, themeColours} = this.props,
+			{foldedSteps, extraSteps, currentQuestion, situation, situationGate, themeColours} = this.props,
 			sim = path =>
 				R.path(R.unless(R.is(Array), R.of)(path))(this.rule.simulateur || {}),
 			reinitalise = () => {
@@ -79,8 +79,6 @@ export default class extends Component {
 				step={step}
 				answer={accessor(step.name)}
 			/>
-
-		let currentQuestion = R.head(unfoldedSteps)
 
 		return (
 			<div id="sim" className={classNames({started})}>

--- a/source/components/Simulateur.js
+++ b/source/components/Simulateur.js
@@ -72,6 +72,16 @@ export default class extends Component {
 			},
 			title = sim('titre') || capitalise0(this.rule['titre'] || this.rule['nom'])
 
+		let buildStep = accessor => step =>
+			<step.component
+				key={step.name}
+				{...step}
+				step={step}
+				answer={accessor(step.name)}
+			/>
+
+		let currentQuestion = R.head(unfoldedSteps)
+
 		return (
 			<div id="sim" className={classNames({started})}>
 				<Helmet>
@@ -98,7 +108,12 @@ export default class extends Component {
 				}
 				{ (started || !sim(['introduction', 'notes'])) &&
 						<Conversation initialValues={ R.pathOr({},['simulateur','par défaut'], sim) }
-							{...{foldedSteps, unfoldedSteps, extraSteps, reinitalise, situation, situationGate, textColourOnWhite: themeColours.textColourOnWhite}}/>
+							{...{
+								reinitalise,
+								foldedSteps: R.map(buildStep(situation), foldedSteps),
+								currentQuestion: currentQuestion && buildStep(situation)({...currentQuestion, unfolded: true}),
+								extraSteps: R.map(buildStep(situationGate), extraSteps),
+								textColourOnWhite: themeColours.textColourOnWhite}}/>
 				}
 
 			</div>

--- a/source/components/Simulateur.js
+++ b/source/components/Simulateur.js
@@ -13,6 +13,7 @@ import './conversation/conversation.css'
 import './Simulateur.css'
 import {capitalise0} from '../utils'
 import Conversation from './conversation/Conversation'
+import {makeQuestion} from 'Engine/generateQuestions'
 
 import ReactPiwik from './Tracker'
 
@@ -72,13 +73,19 @@ export default class extends Component {
 			},
 			title = sim('titre') || capitalise0(this.rule['titre'] || this.rule['nom'])
 
-		let buildStep = accessor => step =>
-			<step.component
+		let buildAnyStep = unfolded => accessor => question => {
+			let step = makeQuestion(rules)(question)
+			return <step.component
 				key={step.name}
 				{...step}
+				{...{unfolded}}
 				step={step}
 				answer={accessor(step.name)}
 			/>
+		}
+
+		let buildStep = buildAnyStep(false)
+		let buildUnfoldedStep = buildAnyStep(true)
 
 		return (
 			<div id="sim" className={classNames({started})}>
@@ -108,8 +115,8 @@ export default class extends Component {
 						<Conversation initialValues={ R.pathOr({},['simulateur','par défaut'], sim) }
 							{...{
 								reinitalise,
+								currentQuestion: currentQuestion && buildUnfoldedStep(situation)(currentQuestion),
 								foldedSteps: R.map(buildStep(situation), foldedSteps),
-								currentQuestion: currentQuestion && buildStep(situation)({...currentQuestion, unfolded: true}),
 								extraSteps: R.map(buildStep(situationGate), extraSteps),
 								textColourOnWhite: themeColours.textColourOnWhite}}/>
 				}

--- a/source/components/conversation/Conversation.js
+++ b/source/components/conversation/Conversation.js
@@ -11,16 +11,7 @@ import Scroll from 'react-scroll'
 })
 export default class Conversation extends Component {
 	render() {
-		let {foldedSteps, unfoldedSteps, extraSteps, reinitalise, situation, situationGate, textColourOnWhite} = this.props,
-			currentQuestion = R.head(unfoldedSteps) ? R.head(unfoldedSteps) : null
-
-		let buildStep = accessor => step =>
-			<step.component
-				key={step.name}
-				{...step}
-				step={step}
-				answer={accessor(step.name)}
-			/>
+		let {foldedSteps, currentQuestion, extraSteps, reinitalise, textColourOnWhite} = this.props
 
 		Scroll.animateScroll.scrollToBottom()
 		return (
@@ -35,25 +26,22 @@ export default class Conversation extends Component {
 									Tout effacer
 								</button>
 							</div>
-							{foldedSteps.map(buildStep(situation))}
+							{foldedSteps}
 						</div>
 					}
-					{unfoldedSteps.length == 0 &&
+					{!currentQuestion &&
 						<Conclusion affiner={!R.isEmpty(extraSteps)}/>}
 					{ !R.isEmpty(extraSteps) &&
 						<div id="foldedSteps">
 							<div className="header" >
 								<h3>Affiner votre situation</h3>
 							</div>
-							{extraSteps.map(buildStep(situationGate))}
+							{extraSteps}
 						</div>
 					}
-					<div id="unfoldedSteps">
-						{ currentQuestion && buildStep(situation)({...currentQuestion, unfolded: true})}
+					<div id="currentQuestion">
+						{ currentQuestion || <Satisfaction simu={this.props.simu}/>}
 					</div>
-					{!currentQuestion &&
-						<Satisfaction simu={this.props.simu}/>
-					}
 				</div>
 				<Aide />
 			</div>

--- a/source/components/conversation/Conversation.js
+++ b/source/components/conversation/Conversation.js
@@ -11,7 +11,8 @@ import Scroll from 'react-scroll'
 })
 export default class Conversation extends Component {
 	render() {
-		let {foldedSteps, unfoldedSteps, extraSteps, reinitalise, situation, situationGate, textColourOnWhite} = this.props
+		let {foldedSteps, unfoldedSteps, extraSteps, reinitalise, situation, situationGate, textColourOnWhite} = this.props,
+			currentQuestion = R.head(unfoldedSteps) ? R.head(unfoldedSteps) : null
 
 		Scroll.animateScroll.scrollToBottom()
 		return (
@@ -56,8 +57,8 @@ export default class Conversation extends Component {
 						</div>
 					}
 					<div id="unfoldedSteps">
-						{ !R.isEmpty(unfoldedSteps) && do {
-							let step = R.head(unfoldedSteps)
+						{ currentQuestion && do {
+							let step = currentQuestion
 							;<step.component
 								key={step.name}
 								step={R.dissoc('component', step)}
@@ -66,7 +67,7 @@ export default class Conversation extends Component {
 							/>
 						}}
 					</div>
-					{R.isEmpty(unfoldedSteps) &&
+					{!currentQuestion &&
 						<Satisfaction simu={this.props.simu}/>
 					}
 				</div>

--- a/source/components/conversation/Conversation.js
+++ b/source/components/conversation/Conversation.js
@@ -14,6 +14,14 @@ export default class Conversation extends Component {
 		let {foldedSteps, unfoldedSteps, extraSteps, reinitalise, situation, situationGate, textColourOnWhite} = this.props,
 			currentQuestion = R.head(unfoldedSteps) ? R.head(unfoldedSteps) : null
 
+		let buildStep = accessor => step =>
+			<step.component
+				key={step.name}
+				{...step}
+				step={step}
+				answer={accessor(step.name)}
+			/>
+
 		Scroll.animateScroll.scrollToBottom()
 		return (
 			<div id="conversation">
@@ -27,15 +35,7 @@ export default class Conversation extends Component {
 									Tout effacer
 								</button>
 							</div>
-							{foldedSteps
-								.map(step => (
-									<step.component
-										key={step.name}
-										{...step}
-										step={step}
-										answer={situation(step.name)}
-									/>
-								))}
+							{foldedSteps.map(buildStep(situation))}
 						</div>
 					}
 					{unfoldedSteps.length == 0 &&
@@ -45,27 +45,11 @@ export default class Conversation extends Component {
 							<div className="header" >
 								<h3>Affiner votre situation</h3>
 							</div>
-							{extraSteps
-								.map(step => (
-									<step.component
-										key={step.name}
-										{...step}
-										step={step}
-										answer={situationGate(step.name)}
-									/>
-								))}
+							{extraSteps.map(buildStep(situationGate))}
 						</div>
 					}
 					<div id="unfoldedSteps">
-						{ currentQuestion && do {
-							let step = currentQuestion
-							;<step.component
-								key={step.name}
-								step={R.dissoc('component', step)}
-								unfolded={true}
-								answer={situation(step.name)}
-							/>
-						}}
+						{ currentQuestion && buildStep(situation)({...currentQuestion, unfolded: true})}
 					</div>
 					{!currentQuestion &&
 						<Satisfaction simu={this.props.simu}/>

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -48,8 +48,7 @@ export var FormDecorator = formType => RenderField =>
 				human,
 				helpText,
 				suggestions,
-				subquestion,
-				objectives,
+				subquestion
 			} = this.props.step
 			this.step = this.props.step
 

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -99,8 +99,9 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (state, action) =
 		let previous = state.currentQuestion,
 			answered = previous && (answerSource(state)(previous) != undefined),
 			foldable = answered ? [previous] : [],
-			foldedSteps = R.without([action.step])(R.concat(state.foldedSteps, foldable)),
-			extraSteps = R.without([action.step], state.extraSteps)
+			foldedSteps = R.without([action.step], R.concat(state.foldedSteps, foldable)),
+			fromExtra = !answered && R.contains(previous, R.keys(softAssumptions)),
+			extraSteps = R.without([action.step], fromExtra ? R.concat(state.extraSteps, [previous]) : state.extraSteps)
 
 		return {
 			...newState,

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -97,14 +97,14 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (state, action) =
 		tracker.push(['trackEvent', 'unfold', action.step]);
 
 		let stepFinder = R.propEq('name', action.step),
-			foldedSteps = R.reject(stepFinder)(state.foldedSteps).concat(state.unfoldedSteps),
-			extraSteps = R.reject(stepFinder)(state.extraSteps)
+			previous = R.head(state.unfoldedSteps),
+			foldedSteps = R.reject(stepFinder)(R.concat(state.foldedSteps, previous ? [previous] : [])),
+			unfolded = R.find(stepFinder)(R.concat(state.foldedSteps, state.extraSteps))
 
 		return {
 			...newState,
 			foldedSteps,
-			extraSteps,
-			unfoldedSteps: [R.find(stepFinder)(R.concat(state.foldedSteps,state.extraSteps))]
+			unfoldedSteps: R.concat([unfolded], state.unfoldedSteps)
 		}
 	}
 }

--- a/test/generateQuestions.test.js
+++ b/test/generateQuestions.test.js
@@ -2,7 +2,7 @@ import R from 'ramda'
 import {expect} from 'chai'
 import {rules as realRules, enrichRule} from '../source/engine/rules'
 import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
-import {buildNextSteps, collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
+import {nextSteps, collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
 
 let stateSelector = (name) => null
 
@@ -218,7 +218,7 @@ describe('collectMissingVariables', function() {
 
 });
 
-describe('buildNextSteps', function() {
+describe('nextSteps', function() {
 
   it('should generate questions', function() {
     let rawRules = [
@@ -228,10 +228,10 @@ describe('buildNextSteps', function() {
           {nom: "ko", espace: "top . sum . evt"}],
         rules = rawRules.map(enrichRule),
         situation = analyseTopDown(rules,"sum")(stateSelector),
-        result = buildNextSteps(stateSelector, rules, situation)
+        result = nextSteps(stateSelector, rules, situation)
 
     expect(result).to.have.lengthOf(1)
-    expect(R.path(["question","props","label"])(result[0])).to.equal("?")
+    expect(result[0]).to.equal("top . sum . evt")
   });
 
   it('should generate questions from the real rules', function() {
@@ -239,7 +239,7 @@ describe('buildNextSteps', function() {
         situation = analyseTopDown(rules,"surcoût CDD")(stateSelector),
         objectives = getObjectives(stateSelector, situation.root, situation.parsedRules),
         missing = collectMissingVariables()(stateSelector,situation),
-        result = buildNextSteps(stateSelector, rules, situation)
+        result = nextSteps(stateSelector, rules, situation)
 
     // expect(objectives).to.have.lengthOf(4)
 
@@ -271,10 +271,10 @@ describe('buildNextSteps', function() {
         situation = analyseTopDown(rules,"Salaire")(stateSelector),
         objectives = getObjectives(stateSelector, situation.root, situation.parsedRules),
         missing = collectMissingVariables()(stateSelector,situation),
-        result = buildNextSteps(stateSelector, rules, situation)
+        result = nextSteps(stateSelector, rules, situation)
 
-    expect(R.path(["question","props","label"])(result[0])).to.equal("Quel est le salaire brut mensuel ?")
-    expect(R.path(["question","props","label"])(result[1])).to.equal("Le contrat est-il à temps partiel ?")
+    expect(result[0]).to.equal("contrat salarié . salaire de base")
+    expect(result[1]).to.equal("contrat salarié . temps partiel")
   });
 
 });

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -65,13 +65,14 @@ describe('fold', function() {
     expect(result.foldedSteps[0]).to.equal("top . aa")
   });
 
-  it('should not list the same question in folded and unfolded', function() {
+  it('should list questions with defaults as extra steps', function() {
     let fakeState = {}
     let stateSelector = state => name => fakeState[name]
 
     let rawRules = [
           // TODO - this won't work without the indirection, figure out why
-          {nom: "startHere", formule: {somme: ["a","b","c"]}, espace: "top"},
+          {nom: "startHere", formule: {somme: ["a","b","c"]}, espace: "top",
+           simulateur: {"par défaut": {"top . bb": 1, "top . cc":0}}},
           {nom: "a", espace: "top", formule: "aa"},
           {nom: "b", espace: "top", formule: "bb"},
           {nom: "c", espace: "top", formule: "cc"},
@@ -84,20 +85,53 @@ describe('fold', function() {
     var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
     fakeState['top . aa'] = 1
     var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
-    fakeState['top . bb'] = 1
-    var step3 = reducer(step2,{type:'STEP_ACTION', name: 'fold', step: 'top . bb'})
-    var step4 = reducer(step3,{type:'STEP_ACTION', name: 'unfold', step: 'top . aa'})
-    var step5 = reducer(step4,{type:'STEP_ACTION', name: 'unfold', step: 'top . bb'})
-    var step6 = reducer(step5,{type:'STEP_ACTION', name: 'fold', step: 'top . bb'})
 
-    let result = step6
+    let result = step2
+
+    expect(result).to.have.property('currentQuestion')
+    expect(result.currentQuestion).to.be.an('null')
+    expect(result).to.have.property('foldedSteps')
+    expect(result.foldedSteps).to.have.lengthOf(1)
+    expect(result.foldedSteps[0]).to.equal("top . aa")
+    expect(result).to.have.property('extraSteps')
+    expect(result.extraSteps).to.have.lengthOf(2)
+    expect(result.extraSteps[0]).to.equal("top . bb")
+    expect(result.extraSteps[1]).to.equal("top . cc")
+  });
+
+  it('should return questions with a default to extra steps', function() {
+    let fakeState = {}
+    let stateSelector = state => name => fakeState[name]
+
+    let rawRules = [
+          // TODO - this won't work without the indirection, figure out why
+          {nom: "startHere", formule: {somme: ["a","b","c"]}, espace: "top",
+           simulateur: {"par défaut": {"top . bb": 1, "top . cc":0}}},
+          {nom: "a", espace: "top", formule: "aa"},
+          {nom: "b", espace: "top", formule: "bb"},
+          {nom: "c", espace: "top", formule: "cc"},
+          {nom: "aa", question: "?", titre: "a", espace: "top"},
+          {nom: "bb", question: "?", titre: "b", espace: "top"},
+          {nom: "cc", question: "?", titre: "c", espace: "top"}],
+        rules = rawRules.map(enrichRule),
+        reducer = reduceSteps(tracker, rules, stateSelector)
+
+    var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
+    fakeState['top . aa'] = 1
+    var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
+    var step3 = reducer(step2,{type:'STEP_ACTION', name: 'unfold', step: 'top . bb'})
+    var step4 = reducer(step3,{type:'STEP_ACTION', name: 'unfold', step: 'top . cc'})
+
+    let result = step4
 
     expect(result).to.have.property('currentQuestion')
     expect(result.currentQuestion).to.equal("top . cc")
     expect(result).to.have.property('foldedSteps')
-    expect(result.foldedSteps).to.have.lengthOf(2)
+    expect(result.foldedSteps).to.have.lengthOf(1)
     expect(result.foldedSteps[0]).to.equal("top . aa")
-    expect(result.foldedSteps[1]).to.equal("top . bb")
+    expect(result).to.have.property('extraSteps')
+    expect(result.extraSteps).to.have.lengthOf(1)
+    expect(result.extraSteps[0]).to.equal("top . bb")
   });
 
 });

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -3,7 +3,7 @@ import R from 'ramda'
 import {expect} from 'chai'
 import {rules as realRules, enrichRule} from '../source/engine/rules'
 import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
-import {buildNextSteps, collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
+import {collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
 
 import {reduceSteps} from '../source/reducers'
 

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -12,7 +12,7 @@ let tracker = {push: array => null}
 
 describe('fold', function() {
 
-  it('should start conversation with only unfolded questions', function() {
+  it('should start conversation with the first missing variable', function() {
     let rawRules = [
           // TODO - this won't work without the indirection, figure out why
           {nom: "startHere", formule: {somme: ["a","b"]}, espace: "top"},
@@ -28,10 +28,8 @@ describe('fold', function() {
         // missing = collectMissingVariables()(stateSelector({}),situation),
         result = reducer({},action)
 
-    expect(result).to.have.property('unfoldedSteps')
-    expect(result.unfoldedSteps).to.have.lengthOf(2)
-    expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . aa")
-    expect(result.unfoldedSteps[1]).to.have.deep.property("name","top . bb")
+    expect(result).to.have.property('currentQuestion')
+    expect(result.currentQuestion).to.have.deep.property("name","top . aa")
   });
 
   it('should deal with double unfold', function() {
@@ -60,10 +58,8 @@ describe('fold', function() {
 
     let result = step5
 
-    expect(result).to.have.property('unfoldedSteps')
-    expect(result.unfoldedSteps).to.have.lengthOf(2)
-    expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . bb")
-    expect(result.unfoldedSteps[1]).to.have.deep.property("name","top . cc")
+    expect(result).to.have.property('currentQuestion')
+    expect(result.currentQuestion).to.have.deep.property("name","top . bb")
     expect(result).to.have.property('foldedSteps')
     expect(result.foldedSteps).to.have.lengthOf(1)
     expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
@@ -96,9 +92,8 @@ describe('fold', function() {
 
     let result = step6
 
-    expect(result).to.have.property('unfoldedSteps')
-    expect(result.unfoldedSteps).to.have.lengthOf(1)
-    expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . cc")
+    expect(result).to.have.property('currentQuestion')
+    expect(result.currentQuestion).to.have.deep.property("name","top . cc")
     expect(result).to.have.property('foldedSteps')
     expect(result.foldedSteps).to.have.lengthOf(2)
     expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -61,12 +61,48 @@ describe('fold', function() {
     let result = step5
 
     expect(result).to.have.property('unfoldedSteps')
-    expect(result.unfoldedSteps).to.have.lengthOf(3)
+    expect(result.unfoldedSteps).to.have.lengthOf(2)
     expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . bb")
+    expect(result.unfoldedSteps[1]).to.have.deep.property("name","top . cc")
+    expect(result).to.have.property('foldedSteps')
+    expect(result.foldedSteps).to.have.lengthOf(1)
+    expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
+  });
+
+  it('should not list the same question in folded and unfolded', function() {
+    let fakeState = {}
+    let stateSelector = state => name => fakeState[name]
+
+    let rawRules = [
+          // TODO - this won't work without the indirection, figure out why
+          {nom: "startHere", formule: {somme: ["a","b","c"]}, espace: "top"},
+          {nom: "a", espace: "top", formule: "aa"},
+          {nom: "b", espace: "top", formule: "bb"},
+          {nom: "c", espace: "top", formule: "cc"},
+          {nom: "aa", question: "?", titre: "a", espace: "top"},
+          {nom: "bb", question: "?", titre: "b", espace: "top"},
+          {nom: "cc", question: "?", titre: "c", espace: "top"}],
+        rules = rawRules.map(enrichRule),
+        reducer = reduceSteps(tracker, rules, stateSelector)
+
+    var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
+    fakeState['top . aa'] = 1
+    var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
+    fakeState['top . bb'] = 1
+    var step3 = reducer(step2,{type:'STEP_ACTION', name: 'fold', step: 'top . bb'})
+    var step4 = reducer(step3,{type:'STEP_ACTION', name: 'unfold', step: 'top . aa'})
+    var step5 = reducer(step4,{type:'STEP_ACTION', name: 'unfold', step: 'top . bb'})
+    var step6 = reducer(step5,{type:'STEP_ACTION', name: 'fold', step: 'top . bb'})
+
+    let result = step6
+
+    expect(result).to.have.property('unfoldedSteps')
+    expect(result.unfoldedSteps).to.have.lengthOf(1)
+    expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . cc")
     expect(result).to.have.property('foldedSteps')
     expect(result.foldedSteps).to.have.lengthOf(2)
-    expect(result.foldedSteps[0]).to.have.deep.property("name","top . cc")
-    expect(result.foldedSteps[1]).to.have.deep.property("name","top . aa")
+    expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
+    expect(result.foldedSteps[1]).to.have.deep.property("name","top . bb")
   });
 
 });

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -40,11 +40,13 @@ describe('fold', function() {
 
     let rawRules = [
           // TODO - this won't work without the indirection, figure out why
-          {nom: "startHere", formule: {somme: ["a","b"]}, espace: "top"},
+          {nom: "startHere", formule: {somme: ["a","b","c"]}, espace: "top"},
           {nom: "a", espace: "top", formule: "aa"},
           {nom: "b", espace: "top", formule: "bb"},
+          {nom: "c", espace: "top", formule: "cc"},
           {nom: "aa", question: "?", titre: "a", espace: "top"},
-          {nom: "bb", question: "?", titre: "b", espace: "top"}],
+          {nom: "bb", question: "?", titre: "b", espace: "top"},
+          {nom: "cc", question: "?", titre: "c", espace: "top"}],
         rules = rawRules.map(enrichRule),
         reducer = reduceSteps(tracker, rules, stateSelector)
 
@@ -59,11 +61,12 @@ describe('fold', function() {
     let result = step5
 
     expect(result).to.have.property('unfoldedSteps')
-    expect(result.unfoldedSteps).to.have.lengthOf(1)
+    expect(result.unfoldedSteps).to.have.lengthOf(3)
     expect(result.unfoldedSteps[0]).to.have.deep.property("name","top . bb")
     expect(result).to.have.property('foldedSteps')
-    expect(result.foldedSteps).to.have.lengthOf(1)
-    expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
+    expect(result.foldedSteps).to.have.lengthOf(2)
+    expect(result.foldedSteps[0]).to.have.deep.property("name","top . cc")
+    expect(result.foldedSteps[1]).to.have.deep.property("name","top . aa")
   });
 
 });

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -29,7 +29,7 @@ describe('fold', function() {
         result = reducer({},action)
 
     expect(result).to.have.property('currentQuestion')
-    expect(result.currentQuestion).to.have.deep.property("name","top . aa")
+    expect(result.currentQuestion).to.equal("top . aa")
   });
 
   it('should deal with double unfold', function() {
@@ -59,10 +59,10 @@ describe('fold', function() {
     let result = step5
 
     expect(result).to.have.property('currentQuestion')
-    expect(result.currentQuestion).to.have.deep.property("name","top . bb")
+    expect(result.currentQuestion).to.equal("top . bb")
     expect(result).to.have.property('foldedSteps')
     expect(result.foldedSteps).to.have.lengthOf(1)
-    expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
+    expect(result.foldedSteps[0]).to.equal("top . aa")
   });
 
   it('should not list the same question in folded and unfolded', function() {
@@ -93,11 +93,11 @@ describe('fold', function() {
     let result = step6
 
     expect(result).to.have.property('currentQuestion')
-    expect(result.currentQuestion).to.have.deep.property("name","top . cc")
+    expect(result.currentQuestion).to.equal("top . cc")
     expect(result).to.have.property('foldedSteps')
     expect(result.foldedSteps).to.have.lengthOf(2)
-    expect(result.foldedSteps[0]).to.have.deep.property("name","top . aa")
-    expect(result.foldedSteps[1]).to.have.deep.property("name","top . bb")
+    expect(result.foldedSteps[0]).to.equal("top . aa")
+    expect(result.foldedSteps[1]).to.equal("top . bb")
   });
 
 });


### PR DESCRIPTION
Refactoring significatif de la logique de la conversation:
 - [X] l'état géré par reduceSteps est désormais: `(currentQuestion, foldedSteps, extraSteps)`
 - [X] reduceSteps ne gère plus que les noms des questions
 - [X] la mise en forme pour représentation des questions est entièrement dans `Simulateur`.
 - [X] `Conversation` ne fait plus aucun traitement

Les bugs liés à l'étape unfold devraient être résolus.