### PR TITLE
:fire: Suppression d'un exemple de trop haut niveau

### DIFF
--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -117,12 +117,6 @@
       - chômage (salarié)
       - APEC (salarié)
       - complémentaire santé (salarié)
-  exemples:
-    - nom: A
-      situation:
-        CSG: 40
-        CRDS: 78.89
-      valeur attendue: 789
 
 - espace: contrat salarié
   nom: cotisations patronales


### PR DESCRIPTION
Remplace #75 (le travail de nettoyer la page /regle dont la section exemple quand elle est vide a été fait dans #97 ). 
@Morendil n'hésite pas à rouvrir #75 si ce n'était pas exactement ça. 