### PR TITLE
inversion des variables de salaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
+    "dedent-js": "^1.0.1",
     "deep-assign": "^2.0.0",
     "ignore-loader": "^0.1.2",
     "install": "^0.10.1",
@@ -97,6 +98,7 @@
     "test": "mocha-webpack --webpack-config source/webpack.test.config.js --require source-map-support/register --require test/helpers/browser.js \"test/**/*.test.js\"",
     "test-watch": "mocha-webpack --webpack-config source/webpack.test.config.js --require source-map-support/register --require test/helpers/browser.js \"test/**/*.test.js\" --watch",
     "test-meca": "mocha-webpack --webpack-config source/webpack.test.config.js --require source-map-support/register --require test/helpers/browser.js test/mecanisms.test.js --watch",
-    "heroku-postbuild": "npm install --dev && webpack --config source/webpack.config.js --progress"
+    "heroku-postbuild": "npm install --dev && webpack --config source/webpack.config.js --progress",
+    "test-inversions": "mocha-webpack --webpack-config source/webpack.test.config.js --require source-map-support/register --require test/helpers/browser.js \"test/inversion.test.js\" --watch"
   }
 }

--- a/règles/rémunération-travail/entités/ok/CDD.yaml
+++ b/règles/rémunération-travail/entités/ok/CDD.yaml
@@ -91,25 +91,11 @@
 # Cette variable est le point de départ du simulateur "surcout CDD" :-D
 - espace: contrat salarié . CDD
   nom: surcoût CDD
-  description: |
-    En France, le contrat à durée déterminée est un contrat d'exception au CDI qui apporte à l'employeur plus de souplesse dans un cadre législatif précis, comportant en particulier des contreparties financières.
-  formule:
-    somme:
+  simulateur:
+    objectifs:
       - salaire net
       - coût du travail
       - CDD . surcoût
-  exemples:
-    - nom: "exemple 1"
-      situation:
-        salaire net: 1000
-        coût du travail: 1610
-        indemnités salarié CDD: 100
-        cotisations employeur CDD: 190
-        prime fin de contrat: 60.4
-        compensation congés payés: 39.6
-      valeur attendue: 2900
-
-  simulateur:
     titre: Simulateur CDD
     sous-titre: Découvrir le surcoût employeur du CDD par rapport au CDI
     introduction:

--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -54,6 +54,9 @@
     salaire médian: 2300
     SMIC: 1480
     SMIC mi-temps: 740
+  inversions possibles:
+    - salaire net
+    - coût du travail
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement

--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -184,18 +184,13 @@
       - exonération JEI
 
 - espace: contrat salarié
-  nom: Salaire
-  description: |
-    Le coût du travail salarial
-  formule:
-    somme: #TODO à l'avenir, exprimer une somme par requête de type : obligation applicable au CDD
+  nom: salaire
+  simulateur:
+    objectifs:
       - salaire net
       - coût du travail
-
-  simulateur:
     titre: Simulateur de coût d'embauche
-    sous-titre: Découvrir le coût d'embauche ou le salaire réel
-    résultats: Le salaire net à partir du brut ou vice-versa, et les cotisations
+    sous-titre: Découvrir le coût d'embauche et le salaire réel
     par défaut:
       contrat salarié . temps partiel: non
       contrat salarié . heures par semaine: 35

--- a/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
+++ b/règles/rémunération-travail/entités/ok/contrat-salarié.yaml
@@ -42,7 +42,7 @@
 - espace: contrat salarié
   nom: salaire de base
   titre: Salaire brut
-  question: Quel est le salaire brut mensuel ?
+  question: Quel est le salaire mensuel ?
   description: |
     C'est le salaire de négociation du contrat de travail en France.
 

--- a/source/actions.js
+++ b/source/actions.js
@@ -30,3 +30,5 @@ export function changeThemeColour(colour) {return {type: CHANGE_THEME_COLOUR, co
 
 
 export const EXPLAIN_VARIABLE = 'EXPLAIN_VARIABLE'
+
+export const SET_INVERSION = 'SET_INVERSION'

--- a/source/components/Results.js
+++ b/source/components/Results.js
@@ -8,13 +8,13 @@ import { withRouter } from 'react-router'
 import './Results.css'
 import {clearDict} from 'Engine/traverse'
 import {encodeRuleName} from 'Engine/rules'
-import {getObjectives} from 'Engine/generateQuestions'
 import RuleValueVignette from './rule/RuleValueVignette'
 
 @withRouter
 @connect(
 	state => ({
-		analysedSituation: state.analysedSituation,
+		analysis: state.analysis,
+		targetName: state.targetName,
 		conversationStarted: !R.isEmpty(state.form),
 		conversationFirstAnswer: R.path(['form', 'conversation', 'values'])(state),
 		situationGate: state.situationGate
@@ -23,37 +23,39 @@ import RuleValueVignette from './rule/RuleValueVignette'
 export default class Results extends Component {
 	componentDidMount(){
 		setTimeout(() =>
-			this.props.setElementHeight(this.el.offsetHeight)
-		, 1)
+			this.el && this.props.setElementHeight(this.el.offsetHeight)
+			, 1)
 	}
 	render() {
 		let {
-			analysedSituation,
+			analysis,
+			targetName,
 			conversationStarted,
 			conversationFirstAnswer: showResults,
-			situationGate,
 			location
 		} = this.props
 
-		let explanation = R.has('root', analysedSituation) && clearDict() && getObjectives(situationGate, analysedSituation.root, analysedSituation.parsedRules)
+		if (!analysis) return null
 
-		if (!explanation) return null
+		let {targets} = analysis
+
+		clearDict() // pourquoi ??
 
 		let onRulePage = R.contains('/regle/')(location.pathname)
 		return (
 			<section ref={el => this.el = el} id="results" className={classNames({show: showResults})}>
 				{onRulePage && conversationStarted ?
 					<div id ="results-actions">
-						<Link id="toSimulation" to={"/simu/" + encodeRuleName(analysedSituation.root.name)}>
+						<Link id="toSimulation" to={'/simu/' + encodeRuleName(targetName)}>
 							<i className="fa fa-arrow-circle-left" aria-hidden="true"></i>Reprendre la simulation
 						</Link>
 					</div>
 					: <div id="results-titles">
-						<h2><i className="fa fa-calculator" aria-hidden="true"></i>{explanation.length == 1 ? 'Votre résultat' : 'Vos résultats'}<span>·</span><small>Cliquez pour comprendre chaque calcul</small></h2>
+						<h2><i className="fa fa-calculator" aria-hidden="true"></i>{targets.length == 1 ? 'Votre résultat' : 'Vos résultats'}<span>·</span><small>Cliquez pour comprendre chaque calcul</small></h2>
 					</div>
 				}
 				<ul>
-					{explanation.map( rule => <li key={rule.nom}>
+					{targets.map( rule => <li key={rule.nom}>
 						<RuleValueVignette {...rule} conversationStarted={conversationStarted} />
 					</li>)}
 				</ul>

--- a/source/components/Simulateur.js
+++ b/source/components/Simulateur.js
@@ -27,11 +27,10 @@ let situationSelector = formValueSelector('conversation')
 		foldedSteps: state.foldedSteps,
 		extraSteps: state.extraSteps,
 		themeColours: state.themeColours,
-		analysedSituation: state.analysedSituation,
 		situationGate: state.situationGate,
 	}),
 	dispatch => ({
-		startConversation: rootVariable => dispatch({type: START_CONVERSATION, rootVariable}),
+		startConversation: targetName => dispatch({type: START_CONVERSATION, targetName}),
 		resetForm: () => dispatch(reset('conversation'))
 	})
 )
@@ -59,7 +58,8 @@ export default class extends Component {
 			this.props.startConversation(name)
 	}
 	render(){
-		if (!this.rule.formule) return <Redirect to={"/regle/" + this.name}/>
+		if (!this.rule.formule && !R.path(['simulateur', 'objectifs'], this.rule))
+			return <Redirect to={'/regle/' + this.name} />
 
 		let
 			{started} = this.state,

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -48,7 +48,8 @@ export var FormDecorator = formType => RenderField =>
 				human,
 				helpText,
 				suggestions,
-				subquestion
+				subquestion,
+				inversions
 			} = this.props.step
 			this.step = this.props.step
 
@@ -58,16 +59,19 @@ export var FormDecorator = formType => RenderField =>
 			des balises html, <input> dans notre cas.
 			*/
 			let stepProps = {
+				name,
 				attributes, /* Input component's html attributes */
 				choices,  /* Question component's radio choices */
 				optionsURL, /* Select component's data source */
 				possibleChoice, /* RhetoricalQuestion component's only choice :'-( */
 				//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 				submit: () => setTimeout(() => stepAction('fold', name), 1),
-				setFormValue: value => setFormValue(name, value),
+				// some forms may want to change the name under which its data is stored
+				setFormValue: (value, formName=name) => setFormValue(formName, value),
 				valueType,
 				suggestions,
-				subquestion
+				subquestion,
+				inversions
 			}
 
 			/* There won't be any answer zone here, widen the question zone */

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import classNames from 'classnames'
 import { connect } from 'react-redux'
 import {Field, change} from 'redux-form'
-import {stepAction} from '../../actions'
+import {stepAction, SET_INVERSION} from '../../actions'
 import StepAnswer from './StepAnswer'
 import {capitalise0} from '../../utils'
 
@@ -21,7 +21,8 @@ export var FormDecorator = formType => RenderField =>
 		}),
 		dispatch => ({
 			stepAction: (name, step) => dispatch(stepAction(name, step)),
-			setFormValue: (field, value) => dispatch(change('conversation', field, value))
+			setFormValue: (field, value) => dispatch(change('conversation', field, value)),
+			setInversion: inversionCouple => dispatch({type: SET_INVERSION, inversionCouple})
 		})
 	)
 	class extends Component {
@@ -35,7 +36,8 @@ export var FormDecorator = formType => RenderField =>
 				setFormValue,
 				/* Une étape déjà répondue est marquée 'folded'. Dans ce dernier cas, un résumé
 				de la réponse est affiché */
-				unfolded
+				unfolded,
+				setInversion
 			} = this.props,
 				{
 				name,
@@ -66,12 +68,12 @@ export var FormDecorator = formType => RenderField =>
 				possibleChoice, /* RhetoricalQuestion component's only choice :'-( */
 				//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 				submit: () => setTimeout(() => stepAction('fold', name), 1),
-				// some forms may want to change the name under which its data is stored
-				setFormValue: (value, formName=name) => setFormValue(formName, value),
+				setFormValue: value => setFormValue(name, value),
 				valueType,
 				suggestions,
 				subquestion,
-				inversions
+				inversions,
+				setInversion
 			}
 
 			/* There won't be any answer zone here, widen the question zone */

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -10,23 +10,22 @@ export default class Input extends Component {
 	}
 	render() {
 		let {
-				name,
 				input,
-				stepProps: { attributes, submit, valueType, suggestions },
+				stepProps: { name, attributes, submit, valueType },
 				meta: { touched, error, active },
 				themeColours
 			} = this.props,
 			answerSuffix = valueType.suffix,
 			suffixed = answerSuffix != null,
 			inputError = touched && error,
-			{hoverSuggestion} = this.state,
+			{ hoverSuggestion } = this.state,
 			sendButtonDisabled =
 				input.value == null || input.value == '' || inputError
 
-		if (typeof suggestions == 'string') return <Select />
 		return (
 			<span>
 				<span className="answer">
+					{this.renderInversions()}
 					<input
 						type="text"
 						{...input}
@@ -74,8 +73,28 @@ export default class Input extends Component {
 			</span>
 		)
 	}
+	renderInversions() {
+		let { stepProps: { name: inputName, inversions } } = this.props
+		if (!inversions) return null
+
+		return [
+			<span>{'Donne la valeur pour' + this.state.inversionName}</span>,
+			<select>
+				{inversions.map(({ name, title, dottedName }) => (
+					<option value={name} selected={dottedName == inputName} onClick={() => this.inverse(dottedName)}>
+						{title || name}
+					</option>
+				))}
+			</select>,
+			<span> de </span>
+		]
+	}
+	inverse(inversionName) {
+		this.setState({inversionName})
+		this.props.stepProps.setFormValue(this.props.input.value, inversionName)
+	}
 	renderSuggestions(themeColours) {
-		let { setFormValue, submit, suggestions, input } = this.props.stepProps
+		let { setFormValue, submit, suggestions } = this.props.stepProps
 		if (!suggestions) return null
 		return (
 			<span className="inputSuggestions">
@@ -85,7 +104,7 @@ export default class Input extends Component {
 						<li
 							key={value}
 							onClick={e =>
-								setFormValue('' + value) && submit() && e.preventDefault()}
+								setFormValue('' + value, this.state.inversionName) && submit() && e.preventDefault()}
 							onMouseOver={() => this.setState({ hoverSuggestion: value })}
 							onMouseOut={() => this.setState({ hoverSuggestion: null })}
 							style={{ color: themeColours.colour }}

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -81,7 +81,7 @@ export default class Input extends Component {
 			<span>{'Donne la valeur pour' + this.state.inversionName}</span>,
 			<select>
 				{inversions.map(({ name, title, dottedName }) => (
-					<option value={name} selected={dottedName == inputName} onClick={() => this.inverse(dottedName)}>
+					<option value={name} selected={dottedName == inputName} onClick={() => this.inverse(inputName, dottedName)}>
 						{title || name}
 					</option>
 				))}
@@ -89,9 +89,12 @@ export default class Input extends Component {
 			<span> de </span>
 		]
 	}
-	inverse(inversionName) {
+	inverse(inputName, inversionName) {
 		this.setState({inversionName})
-		this.props.stepProps.setFormValue(this.props.input.value, inversionName)
+		let inversionCouple = [inputName, inversionName]
+		this.props.stepProps.setInversion(inversionCouple)
+		//todo change the target !
+
 	}
 	renderSuggestions(themeColours) {
 		let { setFormValue, submit, suggestions } = this.props.stepProps

--- a/source/components/rule/Examples.js
+++ b/source/components/rule/Examples.js
@@ -5,7 +5,7 @@ import {
 	rules,
 	disambiguateRuleReference
 } from "Engine/rules.js"
-import { analyseSituation } from "Engine/traverse"
+import { analyse } from "Engine/traverse"
 import "./Examples.css"
 
 export default class Examples extends Component {
@@ -23,10 +23,10 @@ export default class Examples extends Component {
 				R.fromPairs
 			)(ex.situation)
 
-			let runExemple = analyseSituation(rules, rule.name)(
+			let runExemple = analyse(rules, rule.name)(
 					v => exempleSituation[v]
 				),
-				exempleValue = runExemple.nodeValue
+				exempleValue = runExemple.targets[0].nodeValue
 
 			return {
 				...ex,

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux"
 import R from "ramda"
 import "./Rule.css"
 import { rules, decodeRuleName, nameLeaf } from "Engine/rules.js"
-import { analyseSituation } from "Engine/traverse"
+import { analyse } from "Engine/traverse"
 import { START_CONVERSATION } from "../../actions"
 import possiblesDestinataires from "Règles/ressources/destinataires/destinataires.yaml"
 import { capitalise0 } from "../../utils"
@@ -19,8 +19,8 @@ import {createMarkdownDiv} from 'Engine/marked'
 		form: state.form
 	}),
 	dispatch => ({
-		startConversation: rootVariable =>
-			dispatch({ type: START_CONVERSATION, rootVariable })
+		startConversation: targetName =>
+			dispatch({ type: START_CONVERSATION, targetName })
 	})
 )
 export default class Rule extends Component {
@@ -36,9 +36,9 @@ export default class Rule extends Component {
 		}
 	}
 	setRule(name) {
-		this.rule = analyseSituation(rules, nameLeaf(decodeRuleName(name)))(
+		this.rule = analyse(rules, nameLeaf(decodeRuleName(name)))(
 			this.props.situationGate
-		)
+		).targets[0]
 	}
 	componentWillMount() {
 		let { match: { params: { name } } } = this.props

--- a/source/containers/App.dev.js
+++ b/source/containers/App.dev.js
@@ -11,9 +11,7 @@ export default class App extends Component {
 			<Provider store={store}>
 				<div>
 					<Layout />
-					{/*
 					<DevTools />
-					*/}
 				</div>
 			</Provider>
 		)

--- a/source/engine/generateQuestions.js
+++ b/source/engine/generateQuestions.js
@@ -8,7 +8,7 @@ import Select from 'Components/conversation/select/Select'
 import SelectAtmp from 'Components/conversation/select/SelectTauxRisque'
 import formValueTypes from 'Components/conversation/formValueTypes'
 
-import {analyseSituation} from './traverse'
+import {analyseSituation, findInversion} from './traverse'
 import {formValueSelector} from 'redux-form'
 import {rules, findRuleByDottedName} from './rules'
 import {collectNodeMissing, evaluateNode} from './evaluation'
@@ -55,7 +55,14 @@ export let getObjectives = (situationGate, root, parsedRules) => {
 		: (root.formule || root['non applicable si'] || root['applicable si']) ? [root.dottedName] : null,
 		names = targets ? R.reject(R.isNil)(targets) : []
 
+	let inversion = findInversion(situationGate, parsedRules, root)
+
+	if (inversion){
+		return [evaluateNode(situationGate, parsedRules, inversion.fixedObjectiveRule)]
+	}
+
 	let findAndEvaluate = name => evaluateNode(situationGate,parsedRules,findRuleByDottedName(parsedRules,name))
+
 	return R.map(findAndEvaluate,names)
 }
 

--- a/source/engine/generateQuestions.js
+++ b/source/engine/generateQuestions.js
@@ -8,7 +8,7 @@ import Select from 'Components/conversation/select/Select'
 import SelectAtmp from 'Components/conversation/select/SelectTauxRisque'
 import formValueTypes from 'Components/conversation/formValueTypes'
 
-import {findRuleByDottedName} from './rules'
+import {findRuleByDottedName, findRuleByName} from './rules'
 import {collectNodeMissing} from './evaluation'
 
 
@@ -110,6 +110,7 @@ export let makeQuestion = flatRules => dottedName => {
 				placeholder: 'votre réponse',
 			},
 			suggestions: rule.suggestions,
+			inversions: rule['inversions possibles'] && rule['inversions possibles'].map(n => findRuleByName(flatRules, n)).concat([rule])
 		})
 	let selectQuestion = rule => ({
 			component: Select,

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -403,8 +403,57 @@ export let computeRuleValue = (formuleValue, isApplicable) =>
 		? formuleValue
 		: isApplicable === false ? 0 : formuleValue == 0 ? 0 : null
 
+let computeInversion = (objective, computeGivenInput, currentValue) => {
+	let v = currentValue || objective, // notre première approximation est l'objectif lui-même (on suppose donc qu'ils sont du même ordre de grandeur, ce qui est vrai pour les salaires mais pas forcément pour d'autres variables évidemment)
+		here = computeGivenInput(v)
+
+	console.log('coucou', v, here)
+
+	if (Math.abs(here - objective) < 20 ) {
+		return v
+	}
+
+	let
+		ascend = computeGivenInput(v + 10),
+		descend = computeGivenInput(v - 10)
+
+	if (Math.abs(ascend - objective) < Math.abs(descend - objective))
+		return computeInversion(objective, computeGivenInput, v + 10)
+	else
+		return computeInversion(objective, computeGivenInput, v - 10)
+
+}
+
+
 export let treatRuleRoot = (rules, rule) => {
 	let evaluate = (situationGate, parsedRules, r) => {
+		let inversions = r['inversions possibles']
+		if (inversions) {
+			/*
+			Quel inversion possible est renseignée dans la situation courante ?
+			Ex. s'il nous est demandé de calculer le salaire de base, est-ce qu'un candidat à l'inversion, comme
+			le salaire net, a été renseigné ?
+			*/
+			let fixedObjective = inversions.find(name => situationGate(name) != undefined) //TODO ça va foirer avec des espaces de nom
+			//par exemple, fixedObjective = 'salaire net', et v('salaire net') == 2000
+			if (fixedObjective != null) {
+				let
+					fixedObjectiveRule = findRuleByName(parsedRules, fixedObjective),
+					nodeValue = computeInversion(
+						situationGate(fixedObjective),
+						i =>
+							evaluateNode(
+								n => (r.name === n || n === 'sys.filter') ? i : situationGate(n),
+								parsedRules,
+								fixedObjectiveRule
+							).nodeValue
+					)
+
+				return {nodeValue}
+
+			}
+		}
+
 		let evolveRule = R.curry(evaluateNode)(situationGate, parsedRules),
 			evaluated = R.evolve(
 				{

--- a/source/engine/uniroot.js
+++ b/source/engine/uniroot.js
@@ -1,0 +1,116 @@
+/**
+ * Searches the interval from <tt>lowerLimit</tt> to <tt>upperLimit</tt>
+ * for a root (i.e., zero) of the function <tt>func</tt> with respect to
+ * its first argument using Brent's method root-finding algorithm.
+ *
+ * Translated from zeroin.c in http://www.netlib.org/c/brent.shar.
+ *
+ * Copyright (c) 2012 Borgar Thorsteinsson <borgar@borgar.net>
+ * MIT License, http://www.opensource.org/licenses/mit-license.php
+ *
+ * @param {function} function for which the root is sought.
+ * @param {number} the lower point of the interval to be searched.
+ * @param {number} the upper point of the interval to be searched.
+ * @param {number} the desired accuracy (convergence tolerance).
+ * @param {number} the maximum number of iterations.
+ * @returns an estimate for the root within accuracy.
+ *
+ */
+export default function uniroot(func, lowerLimit, upperLimit, errorTol, maxIter) {
+	var a = lowerLimit,
+		b = upperLimit,
+		c = a,
+		fa = func(a),
+		fb = func(b),
+		fc = fa,
+		tol_act, // Actual tolerance
+		new_step, // Step at this iteration
+		prev_step, // Distance from the last but one to the last approximation
+		p, // Interpolation step is calculated in the form p/q; division is delayed until the last moment
+		q
+
+	errorTol = errorTol || 0
+	maxIter = maxIter || 1000
+
+	while (maxIter-- > 0) {
+		prev_step = b - a
+
+		if (Math.abs(fc) < Math.abs(fb)) {
+			// Swap data for b to be the best approximation
+			(a = b), (b = c), (c = a)
+			;(fa = fb), (fb = fc), (fc = fa)
+		}
+
+		tol_act = 1e-15 * Math.abs(b) + errorTol / 2
+		new_step = (c - b) / 2
+
+		if (Math.abs(new_step) <= tol_act || fb === 0) {
+			return b // Acceptable approx. is found
+		}
+
+		// Decide if the interpolation can be tried
+		if (Math.abs(prev_step) >= tol_act && Math.abs(fa) > Math.abs(fb)) {
+			// If prev_step was large enough and was in true direction, Interpolatiom may be tried
+			var t1, cb, t2
+			cb = c - b
+			if (a === c) {
+				// If we have only two distinct points linear interpolation can only be applied
+				t1 = fb / fa
+				p = cb * t1
+				q = 1.0 - t1
+			} else {
+				// Quadric inverse interpolation
+				(q = fa / fc), (t1 = fb / fc), (t2 = fb / fa)
+				p = t2 * (cb * q * (q - t1) - (b - a) * (t1 - 1))
+				q = (q - 1) * (t1 - 1) * (t2 - 1)
+			}
+
+			if (p > 0) {
+				q = -q // p was calculated with the opposite sign; make p positive
+			} else {
+				p = -p // and assign possible minus to q
+			}
+
+			if (
+				p < 0.75 * cb * q - Math.abs(tol_act * q) / 2 &&
+				p < Math.abs(prev_step * q / 2)
+			) {
+				// If (b + p / q) falls in [b,c] and isn't too large it is accepted
+				new_step = p / q
+			}
+
+			// If p/q is too large then the bissection procedure can reduce [b,c] range to more extent
+		}
+
+		if (Math.abs(new_step) < tol_act) {
+			// Adjust the step to be not less than tolerance
+			new_step = new_step > 0 ? tol_act : -tol_act
+		}
+
+		(a = b), (fa = fb) // Save the previous approx.
+		;(b += new_step), (fb = func(b)) // Do step to a new approxim.
+
+		if ((fb > 0 && fc > 0) || (fb < 0 && fc < 0)) {
+			(c = a), (fc = fa) // Adjust c for it to have a sign opposite to that of b
+		}
+	}
+}
+
+/*
+var test_counter;
+function f1 (x) { test_counter++; return (Math.pow(x,2)-1)*x - 5; }
+function f2 (x) { test_counter++; return Math.cos(x)-x; }
+function f3 (x) { test_counter++; return Math.sin(x)-x; }
+function f4 (x) { test_counter++; return (x + 3) * Math.pow(x - 1, 2); }
+[
+  [f1, 2, 3],
+  [f2, 2, 3],
+  [f2, -1, 3],
+  [f3, -1, 3],
+  [f4, -4, 4/3]
+].forEach(function (args) {
+  test_counter = 0;
+  var root = uniroot.apply( pv, args );
+  ;;;console.log( 'uniroot:', args.slice(1), root, test_counter );
+})
+*/

--- a/test/generateQuestions.test.js
+++ b/test/generateQuestions.test.js
@@ -1,27 +1,12 @@
 import R from 'ramda'
 import {expect} from 'chai'
 import {rules as realRules, enrichRule} from '../source/engine/rules'
-import {analyseTopDown} from '../source/engine/traverse'
-import {nextSteps, collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
+import {analyse} from '../source/engine/traverse'
+import {nextSteps, collectMissingVariables} from '../source/engine/generateQuestions'
+
 
 let stateSelector = (name) => null
 
-describe('getObjectives', function() {
-
-  it('should derive objectives from the root rule', function() {
-    let rawRules = [
-          {nom: "startHere", formule: 2, "non applicable si" : "sum . evt . ko", espace: "sum"},
-          {nom: "evt", espace: "sum", formule: {"une possibilité":["ko"]}, titre: "Truc", question:"?"},
-          {nom: "ko", espace: "sum . evt"}],
-        rules = rawRules.map(enrichRule),
-        {root, parsedRules} = analyseTopDown(rules,"startHere")(stateSelector),
-        result = getObjectives(stateSelector, root, parsedRules)
-
-    expect(result).to.have.lengthOf(1)
-    expect(result[0]).to.have.property('name','startHere')
-  });
-
-});
 
 describe('collectMissingVariables', function() {
 
@@ -31,8 +16,8 @@ describe('collectMissingVariables', function() {
           {nom: "evt", espace: "sum", formule: {"une possibilité":["ko"]}, titre: "Truc", question:"?"},
           {nom: "ko", espace: "sum . evt"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
     expect(result).to.have.property('sum . evt . ko')
   });
 
@@ -42,8 +27,8 @@ describe('collectMissingVariables', function() {
           {nom: "nope", espace: "sum . evt"},
           {nom: "nyet", espace: "sum . evt"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.have.property('sum . evt . nyet')
     expect(result).to.have.property('sum . evt . nope')
@@ -54,8 +39,8 @@ describe('collectMissingVariables', function() {
           {nom: "startHere", formule: "trois", "non applicable si" : "3 > 2", espace: "sum"},
           {nom: "trois", espace: "sum"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -65,8 +50,8 @@ describe('collectMissingVariables', function() {
           {nom: "startHere", formule: "trois", "non applicable si" : {"une de ces conditions": ["3 > 2", "trois"]}, espace: "sum"},
           {nom: "trois", espace: "sum"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -76,8 +61,8 @@ describe('collectMissingVariables', function() {
           {nom: "startHere", formule: "trois", espace: "top"},
           {nom: "trois", formule: {"une possibilité":["ko"]}, espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.have.property('top . trois')
   });
@@ -87,8 +72,8 @@ describe('collectMissingVariables', function() {
           {nom: "startHere", formule: "trois", espace: "top"},
           {nom: "trois", formule: {"une possibilité":["ko"]}, "non applicable si": 1, espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -100,8 +85,8 @@ describe('collectMissingVariables', function() {
           {nom: "startHere", formule: "trois", espace: "top"},
           {nom: "trois", formule: {"une possibilité":["ko"]}, espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(mySelector),
-        result = collectMissingVariables()(mySelector,situation)
+        analysis = analyse(rules,"startHere")(mySelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -115,8 +100,8 @@ describe('collectMissingVariables', function() {
               }}, espace: "top"},
           {nom: "dix", espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.have.property('top . dix')
   });
@@ -135,8 +120,8 @@ describe('collectMissingVariables', function() {
           {nom: "dix", espace: "top"},
           {nom: "deux", espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.have.property('top . dix')
     // expect(result).to.have.property('top . deux') - this is a TODO
@@ -156,8 +141,8 @@ describe('collectMissingVariables', function() {
           {nom: "dix", espace: "top"},
           {nom: "deux", espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -170,8 +155,8 @@ describe('collectMissingVariables', function() {
               }}, espace: "top"},
           {nom: "dix", espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -193,8 +178,8 @@ describe('collectMissingVariables', function() {
     { nom: "dix", espace: "top" }
   ],
   rules = rawRules.map(enrichRule),
-  situation = analyseTopDown(rules, "startHere")(stateSelector),
-  result = collectMissingVariables()(stateSelector, situation);
+  analysis = analyse(rules, "startHere")(stateSelector),
+  result = collectMissingVariables(analysis.targets)
 
 
   expect(result).to.have.property('top . dix')
@@ -210,8 +195,8 @@ describe('collectMissingVariables', function() {
               }}, espace: "top"},
           {nom: "dix", espace: "top"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"startHere")(stateSelector),
-        result = collectMissingVariables()(stateSelector,situation)
+        analysis = analyse(rules,"startHere")(stateSelector),
+        result = collectMissingVariables(analysis.targets)
 
     expect(result).to.deep.equal({})
   });
@@ -227,8 +212,8 @@ describe('nextSteps', function() {
           {nom: "evt", espace: "top . sum", formule: {"une possibilité":["ko"]}, titre: "Truc", question:"?"},
           {nom: "ko", espace: "top . sum . evt"}],
         rules = rawRules.map(enrichRule),
-        situation = analyseTopDown(rules,"sum")(stateSelector),
-        result = nextSteps(stateSelector, rules, situation)
+        analysis = analyse(rules,"sum")(stateSelector),
+        result = nextSteps(stateSelector, rules, analysis)
 
     expect(result).to.have.lengthOf(1)
     expect(result[0]).to.equal("top . sum . evt")
@@ -236,10 +221,9 @@ describe('nextSteps', function() {
 
   it('should generate questions from the real rules', function() {
     let rules = realRules.map(enrichRule),
-        situation = analyseTopDown(rules,"surcoût CDD")(stateSelector),
-        objectives = getObjectives(stateSelector, situation.root, situation.parsedRules),
-        missing = collectMissingVariables()(stateSelector,situation),
-        result = nextSteps(stateSelector, rules, situation)
+        analysis = analyse(rules,"surcoût CDD")(stateSelector),
+        missing = collectMissingVariables(analysis.targets),
+        result = nextSteps(stateSelector, rules, analysis)
 
     // expect(objectives).to.have.lengthOf(4)
 
@@ -268,10 +252,9 @@ describe('nextSteps', function() {
     let stateSelector = (name) => ({"contrat salarié . type de contrat":"CDI","entreprise . effectif":"50"})[name]
 
     let rules = realRules.map(enrichRule),
-        situation = analyseTopDown(rules,"Salaire")(stateSelector),
-        objectives = getObjectives(stateSelector, situation.root, situation.parsedRules),
-        missing = collectMissingVariables()(stateSelector,situation),
-        result = nextSteps(stateSelector, rules, situation)
+        analysis = analyse(rules,"Salaire")(stateSelector),
+        missing = collectMissingVariables(analysis.targets),
+        result = nextSteps(stateSelector, rules, analysis)
 
     expect(result[0]).to.equal("contrat salarié . salaire de base")
     expect(result[1]).to.equal("contrat salarié . temps partiel")

--- a/test/generateQuestions.test.js
+++ b/test/generateQuestions.test.js
@@ -1,7 +1,7 @@
 import R from 'ramda'
 import {expect} from 'chai'
 import {rules as realRules, enrichRule} from '../source/engine/rules'
-import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
+import {analyseTopDown} from '../source/engine/traverse'
 import {nextSteps, collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
 
 let stateSelector = (name) => null

--- a/test/inversion.test.js
+++ b/test/inversion.test.js
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { enrichRule } from "../source/engine/rules"
-import { analyseTopDown, analyseSituation } from "../source/engine/traverse"
+import { analyse } from "../source/engine/traverse"
 import { collectMissingVariables } from "../source/engine/generateQuestions"
 import yaml from "js-yaml"
 import dedent from "dedent-js"
@@ -23,9 +23,9 @@ describe("inversions", () => {
 				  format: euro
 			`,
       rules = yaml.safeLoad(rawRules).map(enrichRule),
-      analysis = analyseSituation(rules, "net")(stateSelector)
+      analysis = analyse(rules, "net")(stateSelector)
 
-    expect(analysis.nodeValue).to.be.closeTo(1771, 0.001)
+    expect(analysis.targets[0].nodeValue).to.be.closeTo(1771, 0.001)
   })
 	*/
 
@@ -46,9 +46,9 @@ describe("inversions", () => {
 				    - net
 			`,
       rules = yaml.safeLoad(rawRules).map(enrichRule),
-      analysis = analyseSituation(rules, "brut")(stateSelector)
+      analysis = analyse(rules, "brut")(stateSelector)
 
-    expect(analysis.nodeValue).to.be.closeTo(2000 / (77 / 100), 0.0001 * 2000)
+    expect(analysis.targets[0].nodeValue).to.be.closeTo(2000 / (77 / 100), 0.0001 * 2000)
   })
 
   it("should handle inversions with missing variables", () => {
@@ -71,10 +71,10 @@ describe("inversions", () => {
 			`,
       rules = yaml.safeLoad(rawRules).map(enrichRule),
       stateSelector = name => ({ net: 2000 }[name]),
-      analysis = analyseTopDown(rules, "brut")(stateSelector),
-      missing = collectMissingVariables()(stateSelector, analysis)
+      analysis = analyse(rules, "brut")(stateSelector),
+      missing = collectMissingVariables(analysis.targets)
 
-    expect(analysis.root.nodeValue).to.be.null
+    expect(analysis.targets[0].nodeValue).to.be.null
     expect(missing).to.have.key("cadre")
   })
 })

--- a/test/inversion.test.js
+++ b/test/inversion.test.js
@@ -1,0 +1,53 @@
+import { expect } from "chai"
+import { enrichRule } from "../source/engine/rules"
+import { analyseSituation } from "../source/engine/traverse"
+import yaml from "js-yaml"
+import dedent from 'dedent-js'
+
+describe("inversions", () => {
+	/*
+  it("should handle non inverted example", () => {
+    let fakeState = { brut: 2300 }
+    let stateSelector = name => fakeState[name]
+
+    let
+			rawRules = dedent`
+				- nom: net
+				  formule:
+				    multiplication:
+				      assiette: brut
+				      taux: 77%
+
+				- nom: brut
+				  format: euro
+			`,
+      rules = yaml.safeLoad(rawRules).map(enrichRule),
+      analysis = analyseSituation(rules, "net")(stateSelector)
+
+    expect(analysis.nodeValue).to.be.closeTo(1771, 0.001)
+  })
+	*/
+
+	it("should handle inversions", () => {
+		let fakeState = { net: 2000 }
+		let stateSelector = name => fakeState[name]
+
+		let
+			rawRules = dedent`
+				- nom: net
+				  formule:
+				    multiplication:
+				      assiette: brut
+				      taux: 77%
+
+				- nom: brut
+				  format: euro
+				  inversions possibles: 
+				    - net
+			`,
+			rules = yaml.safeLoad(rawRules).map(enrichRule),
+			analysis = analyseSituation(rules, "brut")(stateSelector)
+
+		expect(analysis.nodeValue).to.be.closeTo(2570, 0.001)
+	})
+})

--- a/test/inversion.test.js
+++ b/test/inversion.test.js
@@ -42,12 +42,12 @@ describe("inversions", () => {
 
 				- nom: brut
 				  format: euro
-				  inversions possibles: 
+				  inversions possibles:
 				    - net
 			`,
 			rules = yaml.safeLoad(rawRules).map(enrichRule),
 			analysis = analyseSituation(rules, "brut")(stateSelector)
 
-		expect(analysis.nodeValue).to.be.closeTo(2570, 0.001)
+		expect(analysis.nodeValue).to.be.closeTo(2000/(77/100), 0.0001*2000)
 	})
 })

--- a/test/mecanisms.test.js
+++ b/test/mecanisms.test.js
@@ -6,7 +6,7 @@
 
 import {expect} from 'chai'
 import {enrichRule} from '../source/engine/rules'
-import {analyseTopDown} from '../source/engine/traverse'
+import {analyse} from '../source/engine/traverse'
 import {collectMissingVariables} from '../source/engine/generateQuestions'
 import testSuites from './load-mecanism-tests'
 import R from 'ramda'
@@ -24,15 +24,16 @@ describe('Mécanismes', () =>
             let rules = suite.map(enrichRule),
               state = situation || {},
               stateSelector = name => state[name],
-              analysis = analyseTopDown(rules, nom)(stateSelector),
-              missing = collectMissingVariables()(stateSelector,analysis)
+              analysis = analyse(rules, nom)(stateSelector),
+              missing = collectMissingVariables(analysis.targets),
+              target = analysis.targets[0]
 
             // console.log('JSON.stringify(analysis', JSON.stringify(analysis))
             if (isFloat(valeur)) {
-              expect(analysis.root.nodeValue).to.be.closeTo(valeur,0.001)
+              expect(target.nodeValue).to.be.closeTo(valeur,0.001)
             }
             else if (valeur !== undefined) {
-              expect(analysis.root)
+              expect(target)
                 .to.have.property(
                   'nodeValue',
                   valeur

--- a/test/reducers.test.js
+++ b/test/reducers.test.js
@@ -2,7 +2,6 @@ import R from 'ramda'
 
 import {expect} from 'chai'
 import {rules as realRules, enrichRule} from '../source/engine/rules'
-import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
 import {collectMissingVariables, getObjectives} from '../source/engine/generateQuestions'
 
 import {reduceSteps} from '../source/reducers'
@@ -22,10 +21,10 @@ describe('fold', function() {
           {nom: "bb", question: "?", titre: "b", espace: "top"}],
         rules = rawRules.map(enrichRule),
         reducer = reduceSteps(tracker, rules, stateSelector),
-        action = {type:'START_CONVERSATION', rootVariable: 'startHere'},
+        action = {type:'START_CONVERSATION', targetName: 'startHere'},
         // situation = analyseTopDown(rules,"startHere")(stateSelector({})),
         // objectives = getObjectives(stateSelector({}), situation.root, situation.parsedRules),
-        // missing = collectMissingVariables()(stateSelector({}),situation),
+        // missing = collectMissingVariables(stateSelector({}),situation),
         result = reducer({},action)
 
     expect(result).to.have.property('currentQuestion')
@@ -48,7 +47,7 @@ describe('fold', function() {
         rules = rawRules.map(enrichRule),
         reducer = reduceSteps(tracker, rules, stateSelector)
 
-    var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
+    var step1 = reducer({},{type:'START_CONVERSATION', targetName: 'startHere'})
     fakeState['top . aa'] = 1
     var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
     fakeState['top . bb'] = 1
@@ -82,7 +81,7 @@ describe('fold', function() {
         rules = rawRules.map(enrichRule),
         reducer = reduceSteps(tracker, rules, stateSelector)
 
-    var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
+    var step1 = reducer({},{type:'START_CONVERSATION', targetName: 'startHere'})
     fakeState['top . aa'] = 1
     var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
 
@@ -116,7 +115,7 @@ describe('fold', function() {
         rules = rawRules.map(enrichRule),
         reducer = reduceSteps(tracker, rules, stateSelector)
 
-    var step1 = reducer({},{type:'START_CONVERSATION', rootVariable: 'startHere'})
+    var step1 = reducer({},{type:'START_CONVERSATION', targetName: 'startHere'})
     fakeState['top . aa'] = 1
     var step2 = reducer(step1,{type:'STEP_ACTION', name: 'fold', step: 'top . aa'})
     var step3 = reducer(step2,{type:'STEP_ACTION', name: 'unfold', step: 'top . bb'})

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -1,7 +1,6 @@
 import R from 'ramda'
 import {expect} from 'chai'
 import {rules, enrichRule, findVariantsAndRecords} from '../source/engine/rules'
-import {analyseSituation, analyseTopDown} from '../source/engine/traverse'
 
 let stateSelector = (state, name) => null
 


### PR DESCRIPTION
Permettre l'inversion de variables grâce à la nouvelle propriété 'inversions possibles'.

Une inversion, c'est par exemple saisir `salaire net` au lieu de `salaire brut` : le moteur se charge de retrouver le salaire brut qui donne le salaire net désiré, et calcule les autres variables en fonction de ce salaire brut. 

- [x] Gérer l'inversion dans le moteur sur un test basique
- [x] Sur un test avec des variables manquantes
- [ ] Implémenter l'UI

L'UI : 

La question du salaire brut devient : "Quel est le salaire". La réponse devient au choix : 

`2300€ [net / brut / de coût du travail] par mois`

Ou mieux, je trouve, car on choisit l'objectif avant d'entrer le montant : 

`[salaire net / salaire brut / coût du travail] de 2300€ par mois`

Permettre à l'utilisateur de faire son choix _dans la question_ me semble être une mauvaise idée car on brouille les zones de question avec les zones de saisie. 

- [x] Refactorer : 
`getObjectives` dans generateQuestions.js est un patch qui vient combler le fait qu'on ne gère pas l'analyse d'une simple liste d'objectifs : on est obligés d'en faire une somme artificielle. Cette PR vient patcher le patch, il est temps d'en finir :laughing: 

Bonus : 
- [ ] Inverser les suggestions aussi
- [ ] Mettre les bulles d'information sur les inversions possibles
